### PR TITLE
fix(desktop): update zen mode shortcut key notation

### DIFF
--- a/apps/desktop/src/renderer/src/constants/shortcuts.ts
+++ b/apps/desktop/src/renderer/src/constants/shortcuts.ts
@@ -37,7 +37,7 @@ const shortcutConfigs = {
     },
     zenMode: {
       name: "keys.layout.zenMode",
-      key: "Control+Shift+Z",
+      key: "Ctrl+Shift+Z",
     },
   },
   entries: {


### PR DESCRIPTION
Before:

![CleanShot 2025-03-19 at 09 39 34](https://github.com/user-attachments/assets/48e3eae5-cb61-4327-bc15-6c5ec3bbef39)

After:

![CleanShot 2025-03-19 at 09 39 18](https://github.com/user-attachments/assets/4c3a0953-c2a0-4f53-99ac-c1e5634376b8)
