### PR TITLE
fix(desktop): add type attribute to sign up button

### DIFF
--- a/apps/desktop/src/renderer/src/modules/auth/Form.tsx
+++ b/apps/desktop/src/renderer/src/modules/auth/Form.tsx
@@ -133,6 +133,7 @@ export function LoginWithPassword({ runtime }: { runtime: LoginRuntime }) {
             {t("login.continueWith", { provider: t("words.email") })}
           </Button>
           <Button
+            type="button"
             variant="outline"
             size="lg"
             onClick={() => {


### PR DESCRIPTION
Cause the login form check not as expected

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When not logged in, in the login form, clicking the Sign up button causes a form submission. This is clearly attributable to an incorrect button type setting or the utilization of the default value.

### Change

Just added a `type` attribute with the value "button" to the Sign up button.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

I suggest for future development, consider using lint to prevent this issue. Or, specify a default `type` to replace the standard default "submit", only explicitly triggering the submit action when submission is actually needed, or detach the button from the form.

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
