### PR TITLE
fix: navigation status when entering from other pages

### DIFF
--- a/apps/desktop/src/renderer/src/modules/app-layout/subview/index.electron.tsx
+++ b/apps/desktop/src/renderer/src/modules/app-layout/subview/index.electron.tsx
@@ -65,7 +65,11 @@ export function SubviewLayout() {
       >
         <MotionButtonBase
           onClick={() => {
-            navigate(prevLocation)
+            if (prevLocation.pathname === location.pathname) {
+              navigate({ pathname: "" })
+            } else {
+              navigate(prevLocation)
+            }
           }}
           className="no-drag-region hover:text-accent inline-flex items-center gap-1 duration-200"
         >

--- a/apps/desktop/src/renderer/src/modules/timeline-column/index.tsx
+++ b/apps/desktop/src/renderer/src/modules/timeline-column/index.tsx
@@ -55,7 +55,7 @@ export function FeedColumn({ children, className }: PropsWithChildren<{ classNam
     listId: s.listId,
   }))
 
-  const [timelineId, setMemoizedTimelineId] = useState(routeParams.timelineId)
+  const [timelineId, setMemoizedTimelineId] = useState(routeParams.timelineId ?? timelineList[0])
 
   useEffect(() => {
     if (routeParams.timelineId) setMemoizedTimelineId(routeParams.timelineId)


### PR DESCRIPTION
This PR fixes the navigation status when entering from pages like action or discover.

- Can not go back to home
- No fallback subscription list