### PR TITLE
refactor: enhance toolbar customization and mobile view actions

### DIFF
--- a/apps/desktop/src/renderer/src/modules/customize-toolbar/constant.ts
+++ b/apps/desktop/src/renderer/src/modules/customize-toolbar/constant.ts
@@ -7,24 +7,17 @@ export interface ToolbarActionOrder {
   more: UniqueIdentifier[]
 }
 
+const entryItemInMore = new Set<string>([
+  COMMAND_ID.entry.copyLink,
+  COMMAND_ID.entry.openInBrowser,
+  COMMAND_ID.entry.exportAsPDF,
+  COMMAND_ID.entry.read,
+])
+
 export const DEFAULT_ACTION_ORDER: ToolbarActionOrder = {
-  main: Object.values(COMMAND_ID.entry)
-    .filter((id) => !([COMMAND_ID.entry.read] as string[]).includes(id))
-    .filter(
-      (id) =>
-        !([COMMAND_ID.entry.copyLink, COMMAND_ID.entry.openInBrowser] as string[]).includes(id),
-    ),
+  main: Object.values(COMMAND_ID.entry).filter((id) => !entryItemInMore.has(id)),
   more: [
     ...Object.values(COMMAND_ID.integration),
-    ...Object.values(COMMAND_ID.entry).filter((id) =>
-      (
-        [
-          COMMAND_ID.entry.copyLink,
-          COMMAND_ID.entry.openInBrowser,
-          COMMAND_ID.entry.exportAsPDF,
-          COMMAND_ID.entry.read,
-        ] as string[]
-      ).includes(id),
-    ),
+    ...Object.values(COMMAND_ID.entry).filter((id) => entryItemInMore.has(id)),
   ],
 }

--- a/apps/desktop/src/renderer/src/modules/customize-toolbar/modal.tsx
+++ b/apps/desktop/src/renderer/src/modules/customize-toolbar/modal.tsx
@@ -78,7 +78,10 @@ const CustomizeToolbar = () => {
   }, [])
 
   return (
-    <div className="mx-auto w-full max-w-[800px] space-y-4">
+    <div
+      className="mx-auto w-full max-w-[800px] space-y-4"
+      onPointerDown={(event) => event.stopPropagation()}
+    >
       <div className="mb-4">
         <h2 className="text-lg font-semibold">{t("customizeToolbar.quick_actions.title")}</h2>
         <p className="text-sm text-gray-500">{t("customizeToolbar.quick_actions.description")}</p>

--- a/apps/desktop/src/renderer/src/modules/entry-content/header.electron.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/header.electron.tsx
@@ -71,7 +71,7 @@ function EntryHeaderImpl({ view, entryId, className, compact }: EntryHeaderProps
           </AnimatePresence>
         </div>
 
-        <div className="relative flex shrink-0 items-center justify-end gap-3">
+        <div className="relative flex shrink-0 items-center justify-end gap-2">
           {!compact && <ElectronAdditionActions view={view} entry={entry} key={entry.entries.id} />}
 
           <ImageGalleryAction id={entry.entries.id} />

--- a/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
@@ -19,6 +19,7 @@ import { useEntry } from "~/store/entry/hooks"
 
 import { useCommand } from "../command/hooks/use-command"
 import type { FollowCommandId } from "../command/types"
+import { MoreActions } from "./actions/more-actions"
 import { useEntryContentScrollToTop, useEntryTitleMeta } from "./atoms"
 import type { EntryHeaderProps } from "./header.shared"
 
@@ -93,6 +94,7 @@ function EntryHeaderImpl({ view, entryId, className }: EntryHeaderProps) {
               shortcut={item.shortcut}
             />
           ))}
+          <MoreActions entryId={entryId} />
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
@@ -80,7 +80,7 @@ function EntryHeaderImpl({ view, entryId, className }: EntryHeaderProps) {
 
         <div
           className={clsx(
-            "relative flex shrink-0 items-center justify-end gap-3",
+            "relative flex shrink-0 items-center justify-end gap-2",
             shouldShowMeta && "hidden",
           )}
         >

--- a/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/header.mobile.tsx
@@ -4,7 +4,7 @@ import { findElementInShadowDOM } from "@follow/utils/dom"
 import { clsx, cn } from "@follow/utils/utils"
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer"
 import { AnimatePresence, m } from "framer-motion"
-import { memo, useEffect, useMemo, useState } from "react"
+import { memo, useEffect, useState } from "react"
 import { RemoveScroll } from "react-remove-scroll"
 import { useEventCallback } from "usehooks-ts"
 
@@ -17,7 +17,6 @@ import type { EntryActionItem } from "~/hooks/biz/useEntryActions"
 import { useSortedEntryActions } from "~/hooks/biz/useEntryActions"
 import { useEntry } from "~/store/entry/hooks"
 
-import { COMMAND_ID } from "../command/commands/id"
 import { useCommand } from "../command/hooks/use-command"
 import type { FollowCommandId } from "../command/types"
 import { useEntryContentScrollToTop, useEntryTitleMeta } from "./atoms"
@@ -26,16 +25,7 @@ import type { EntryHeaderProps } from "./header.shared"
 function EntryHeaderImpl({ view, entryId, className }: EntryHeaderProps) {
   const entry = useEntry(entryId)
   const sortedActionConfigs = useSortedEntryActions({ entryId, view })
-  const actionConfigs = useMemo(
-    () =>
-      [...sortedActionConfigs.mainAction, ...sortedActionConfigs.moreAction].filter(
-        (item) =>
-          !([COMMAND_ID.entry.copyLink, COMMAND_ID.settings.customizeToolbar] as string[]).includes(
-            item.id,
-          ),
-      ),
-    [sortedActionConfigs.mainAction, sortedActionConfigs.moreAction],
-  )
+  const actionConfigs = sortedActionConfigs.mainAction
 
   const entryTitleMeta = useEntryTitleMeta()
   const isAtTop = useEntryContentScrollToTop()

--- a/apps/desktop/src/renderer/src/modules/settings/tabs/apperance.tsx
+++ b/apps/desktop/src/renderer/src/modules/settings/tabs/apperance.tsx
@@ -30,6 +30,7 @@ import {
 import { useCurrentModal, useModalStack } from "~/components/ui/modal/stacked/hooks"
 import { isElectronBuild } from "~/constants"
 import { useSetTheme } from "~/hooks/common"
+import { useShowCustomizeToolbarModal } from "~/modules/customize-toolbar/modal"
 
 import { SETTING_MODAL_ID } from "../constants"
 import {
@@ -145,6 +146,7 @@ export const SettingAppearance = () => {
             description: t("appearance.use_pointer_cursor.description"),
             hide: isMobile,
           }),
+          CustomizeToolbar,
         ]}
       />
     </div>
@@ -495,5 +497,26 @@ const DateFormat = () => {
         size="sm"
       />
     </div>
+  )
+}
+
+/**
+ * @description customize the toolbar actions
+ */
+const CustomizeToolbar = () => {
+  const { t } = useTranslation("settings")
+  const showModal = useShowCustomizeToolbarModal()
+
+  return (
+    <SettingItemGroup>
+      <SettingActionItem
+        label={<span className="flex items-center gap-1">{t("customizeToolbar.title")}</span>}
+        action={async () => {
+          showModal()
+        }}
+        buttonText={t("customizeToolbar.title")}
+      />
+      <SettingDescription>{t("customizeToolbar.quick_actions.description")}</SettingDescription>
+    </SettingItemGroup>
   )
 }


### PR DESCRIPTION
Streamline the order of toolbar actions using a Set, add a customization option for toolbar actions in settings, and ensure only the main action displays in mobile view.

<img width="788" alt="image" src="https://github.com/user-attachments/assets/324eb748-54fe-4194-83d6-96c74161b610" />
