### PR TITLE
feat(desktop): add estimated audio duration display for entry-title

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/markdown/renderers/MarkdownP.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/markdown/renderers/MarkdownP.tsx
@@ -16,12 +16,12 @@ export const MarkdownP: Component<
   if (parseTimeline && Array.isArray(children)) {
     return (
       <p>
-        {children.map((child) => {
+        {children.map((child, index) => {
           if (typeof child === "string") {
             const renderer = ensureAndRenderTimeStamp(child)
-            if (renderer) return renderer
+            if (renderer) return <React.Fragment key={index}>{renderer}</React.Fragment>
           }
-          return child
+          return <React.Fragment key={index}>{child}</React.Fragment>
         })}
       </p>
     )

--- a/apps/desktop/src/renderer/src/modules/entry-content/components/EntryTitle.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/components/EntryTitle.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@follow/utils/utils"
+import { cn, formatEstimatedMins } from "@follow/utils/utils"
 import dayjs from "dayjs"
 import { useMemo } from "react"
 
@@ -74,6 +74,25 @@ export const EntryTitle = ({ entryId, compact }: EntryLinkProps) => {
     return dayjs(entry.entries.publishedAt).format(dateFormat)
   }, [dateFormat, entry?.entries.publishedAt])
 
+  const audioAttachment = useMemo(() => {
+    return entry?.entries?.attachments?.find((a) => a.mime_type?.startsWith("audio") && a.url)
+  }, [entry?.entries?.attachments])
+
+  const estimatedMins = useMemo(() => {
+    if (!audioAttachment?.duration_in_seconds) {
+      return
+    }
+
+    let durationInSeconds = audioAttachment.duration_in_seconds
+
+    if (Number.isNaN(+durationInSeconds)) {
+      // @ts-expect-error durationInSeconds is string
+      durationInSeconds = formatTimeToSeconds(durationInSeconds)
+    }
+
+    return formatEstimatedMins(Math.floor(durationInSeconds / 60))
+  }, [audioAttachment])
+
   if (!entry) return null
 
   return compact ? (
@@ -114,6 +133,13 @@ export const EntryTitle = ({ entryId, compact }: EntryLinkProps) => {
       </div>
       <div className="flex select-none items-center gap-2 text-[13px] text-zinc-500">
         {dateRender}
+
+        {estimatedMins && (
+          <div className="flex items-center gap-1">
+            <i className="i-mgc-time-cute-re" />
+            <span>{estimatedMins}</span>
+          </div>
+        )}
 
         <div className="flex items-center gap-1">
           <i className="i-mgc-eye-2-cute-re" />


### PR DESCRIPTION
Normal article:

<img src="https://github.com/user-attachments/assets/75192071-582b-4c39-b528-0e923f4a0116" width="300" />

Audio:

<img src="https://github.com/user-attachments/assets/b3adcf3a-fd5e-4d52-bdee-646c64d4a0f0" width="300" />