### PR TITLE
fix(desktop): miss related methods in entry-title

### DIFF
--- a/apps/desktop/src/renderer/src/modules/entry-content/components/EntryTitle.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/components/EntryTitle.tsx
@@ -1,4 +1,4 @@
-import { cn, formatEstimatedMins } from "@follow/utils/utils"
+import { cn, formatEstimatedMins, formatTimeToSeconds } from "@follow/utils/utils"
 import dayjs from "dayjs"
 import { useMemo } from "react"
 


### PR DESCRIPTION
Related: #3292

Add a `ts-expect-error`  tag that made me forget to import this method.