### PR TITLE
fix(desktop): remove incorrect PDF export notification

### DIFF
--- a/apps/desktop/src/renderer/src/modules/command/commands/entry.tsx
+++ b/apps/desktop/src/renderer/src/modules/command/commands/entry.tsx
@@ -188,10 +188,6 @@ export const useRegisterEntryCommands = () => {
         }
 
         window.print()
-
-        toast(t("entry_actions.exported_notify"), {
-          duration: 1000,
-        })
       },
     },
     {

--- a/locales/app/ar-DZ.json
+++ b/locales/app/ar-DZ.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختر",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل في الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل في الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_obsidian": "فشل في الحفظ إلى Obsidian.",

--- a/locales/app/ar-IQ.json
+++ b/locales/app/ar-IQ.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختر",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل في الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل في الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_obsidian": "فشل في الحفظ إلى Obsidian.",

--- a/locales/app/ar-KW.json
+++ b/locales/app/ar-KW.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختر",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل في الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل في الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_obsidian": "فشل في الحفظ إلى Obsidian",

--- a/locales/app/ar-MA.json
+++ b/locales/app/ar-MA.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختر",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_obsidian": "فشل الحفظ في Obsidian",

--- a/locales/app/ar-SA.json
+++ b/locales/app/ar-SA.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختيار",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل في الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل في الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_readwise": "فشل في الحفظ إلى Readwise.",

--- a/locales/app/ar-TN.json
+++ b/locales/app/ar-TN.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "اختر",
   "entry_actions.copy_link": "نسخ الرابط",
   "entry_actions.export_as_pdf": "تصدير كملف PDF",
-  "entry_actions.exported_notify": "تم تصدير المقال كملف PDF.",
   "entry_actions.failed_to_save_to_eagle": "فشل في الحفظ إلى Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "فشل في الحفظ إلى Instapaper.",
   "entry_actions.failed_to_save_to_readwise": "فشل في الحفظ إلى Readwise.",

--- a/locales/app/de.json
+++ b/locales/app/de.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "Auswählen",
   "entry_actions.copy_link": "Link kopieren",
   "entry_actions.export_as_pdf": "Als PDF exportieren",
-  "entry_actions.exported_notify": "Artikel als PDF exportiert.",
   "entry_actions.failed_to_save_to_eagle": "Speichern in Eagle fehlgeschlagen.",
   "entry_actions.failed_to_save_to_instapaper": "Speichern in Instapaper fehlgeschlagen.",
   "entry_actions.failed_to_save_to_obsidian": "Speichern in Obsidian fehlgeschlagen",

--- a/locales/app/en.json
+++ b/locales/app/en.json
@@ -88,7 +88,6 @@
   "entry_actions.delete": "Delete",
   "entry_actions.deleted": "Deleted.",
   "entry_actions.export_as_pdf": "Export as PDF",
-  "entry_actions.exported_notify": "Exported article as PDF.",
   "entry_actions.failed_to_delete": "Failed to delete.",
   "entry_actions.failed_to_save_to_eagle": "Failed to save to Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "Failed to save to Instapaper.",

--- a/locales/app/es.json
+++ b/locales/app/es.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "Seleccionar",
   "entry_actions.copy_link": "Copiar enlace",
   "entry_actions.export_as_pdf": "Exportar como PDF",
-  "entry_actions.exported_notify": "Artículo exportado como PDF.",
   "entry_actions.failed_to_save_to_obsidian": "Error al guardar en Obsidian",
   "entry_actions.mark_as_read": "Marcar como leído",
   "entry_actions.mark_as_unread": "Marcar como no leído",

--- a/locales/app/fi.json
+++ b/locales/app/fi.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "Valitse",
   "entry_actions.copy_link": "Kopioi linkki",
   "entry_actions.export_as_pdf": "Vie PDF:nä",
-  "entry_actions.exported_notify": "Artikkeli vietiin PDF-muodossa.",
   "entry_actions.failed_to_save_to_eagle": "Tallennus Eagleen epäonnistui.",
   "entry_actions.failed_to_save_to_instapaper": "Tallennus Instapaperiin epäonnistui.",
   "entry_actions.failed_to_save_to_readwise": "Tallennus Readwiseen epäonnistui.",

--- a/locales/app/fr.json
+++ b/locales/app/fr.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "Sélectionner",
   "entry_actions.copy_link": "Copier le lien",
   "entry_actions.export_as_pdf": "Exporter en PDF",
-  "entry_actions.exported_notify": "Article exporté en PDF.",
   "entry_actions.failed_to_save_to_eagle": "Échec de l'enregistrement sur Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "Échec de l'enregistrement sur Instapaper.",
   "entry_actions.failed_to_save_to_readwise": "Échec de l'enregistrement sur Readwise.",

--- a/locales/app/it.json
+++ b/locales/app/it.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "Seleziona",
   "entry_actions.copy_link": "Copia link",
   "entry_actions.export_as_pdf": "Esporta come PDF",
-  "entry_actions.exported_notify": "Articolo esportato come PDF.",
   "entry_actions.failed_to_save_to_eagle": "Salvataggio su Eagle non riuscito.",
   "entry_actions.failed_to_save_to_instapaper": "Salvataggio su Instapaper non riuscito.",
   "entry_actions.failed_to_save_to_readwise": "Salvataggio su Readwise non riuscito.",

--- a/locales/app/ja.json
+++ b/locales/app/ja.json
@@ -88,7 +88,6 @@
   "entry_actions.delete": "削除",
   "entry_actions.deleted": "削除済み",
   "entry_actions.export_as_pdf": "PDFとしてエクスポート",
-  "entry_actions.exported_notify": "記事をPDFとしてエクスポートしました。",
   "entry_actions.failed_to_delete": "削除に失敗しました。",
   "entry_actions.failed_to_save_to_eagle": "Eagle への保存に失敗しました。",
   "entry_actions.failed_to_save_to_instapaper": "Instapaper への保存に失敗しました。",

--- a/locales/app/ko.json
+++ b/locales/app/ko.json
@@ -88,7 +88,6 @@
   "entry_actions.delete": "삭제",
   "entry_actions.deleted": "삭제됨",
   "entry_actions.export_as_pdf": "PDF로 내보내기",
-  "entry_actions.exported_notify": "PDF로 기사 내보내기 완료.",
   "entry_actions.failed_to_delete": "삭제 실패",
   "entry_actions.failed_to_save_to_eagle": "Eagle에 저장하지 못했습니다",
   "entry_actions.failed_to_save_to_instapaper": "Instapaper에 저장하지 못했습니다",

--- a/locales/app/pt.json
+++ b/locales/app/pt.json
@@ -16,7 +16,6 @@
   "discover.select_placeholder": "選択",
   "entry_actions.copy_link": "リンクをコピー",
   "entry_actions.export_as_pdf": "Exportar como PDF",
-  "entry_actions.exported_notify": "Artigo exportado como PDF.",
   "entry_actions.failed_to_save_to_eagle": "Eagle への保存に失敗しました。",
   "entry_actions.failed_to_save_to_instapaper": "Instapaper への保存に失敗しました。",
   "entry_actions.failed_to_save_to_readwise": "Readwise への保存に失敗しました。",

--- a/locales/app/ru.json
+++ b/locales/app/ru.json
@@ -84,7 +84,6 @@
   "entry_actions.delete": "Удалить",
   "entry_actions.deleted": "Удалено.",
   "entry_actions.export_as_pdf": "Экспортировать в PDF",
-  "entry_actions.exported_notify": "Статья экспортирована в PDF.",
   "entry_actions.failed_to_delete": "Не удалось удалить.",
   "entry_actions.failed_to_save_to_eagle": "Не удалось сохранить в Eagle.",
   "entry_actions.failed_to_save_to_instapaper": "Не удалось сохранить в Instapaper.",

--- a/locales/app/tr.json
+++ b/locales/app/tr.json
@@ -29,7 +29,6 @@
   "discover.target.lists": "Listeler",
   "entry_actions.copy_link": "Bağlantıyı kopyala",
   "entry_actions.export_as_pdf": "PDF olarak dışa aktar",
-  "entry_actions.exported_notify": "Makale PDF olarak dışa aktarıldı.",
   "entry_actions.failed_to_save_to_eagle": "Eagle'a kaydetme başarısız oldu.",
   "entry_actions.failed_to_save_to_instapaper": "Instapaper'a kaydetme başarısız oldu.",
   "entry_actions.failed_to_save_to_readwise": "Readwise'a kaydetme başarısız oldu.",

--- a/locales/app/zh-CN.json
+++ b/locales/app/zh-CN.json
@@ -88,7 +88,6 @@
   "entry_actions.delete": "删除",
   "entry_actions.deleted": "已删除",
   "entry_actions.export_as_pdf": "导出为 PDF",
-  "entry_actions.exported_notify": "文章已导出为 PDF。",
   "entry_actions.failed_to_delete": "删除失败",
   "entry_actions.failed_to_save_to_eagle": "保存到 Eagle 失败。",
   "entry_actions.failed_to_save_to_instapaper": "保存到 Instapaper 失败。",

--- a/locales/app/zh-HK.json
+++ b/locales/app/zh-HK.json
@@ -88,7 +88,6 @@
   "entry_actions.delete": "刪除",
   "entry_actions.deleted": "已刪除",
   "entry_actions.export_as_pdf": "匯出為 PDF",
-  "entry_actions.exported_notify": "文章已匯出為 PDF。",
   "entry_actions.failed_to_delete": "無法刪除",
   "entry_actions.failed_to_save_to_eagle": "無法儲存至 Eagle",
   "entry_actions.failed_to_save_to_instapaper": "無法儲存至 Instapaper",

--- a/locales/app/zh-TW.json
+++ b/locales/app/zh-TW.json
@@ -85,7 +85,6 @@
   "entry_actions.delete": "刪除",
   "entry_actions.deleted": "已刪除。",
   "entry_actions.export_as_pdf": "匯出為 PDF",
-  "entry_actions.exported_notify": "文章已匯出為 PDF。",
   "entry_actions.failed_to_delete": "刪除失敗。",
   "entry_actions.failed_to_save_to_eagle": "無法儲存到 Eagle。",
   "entry_actions.failed_to_save_to_instapaper": "無法儲存到 Instapaper。",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The "Export as PDF" feature uses the `window.print()` method, which cannot determine whether the user has successfully exported the PDF. The current toast message is misleading, so it is recommended to remove it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
