### PR TITLE
style(desktop): optimize entry content header 1px offset

### DIFF
--- a/apps/desktop/src/renderer/src/modules/entry-content/header.electron.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/header.electron.tsx
@@ -29,7 +29,7 @@ function EntryHeaderImpl({ view, entryId, className, compact }: EntryHeaderProps
     <div
       data-hide-in-print
       className={cn(
-        "zen-mode-macos:ml-margin-macos-traffic-light-x relative flex min-w-0 items-center justify-between gap-3 overflow-hidden border-b border-transparent text-lg text-zinc-500 duration-200",
+        "zen-mode-macos:ml-margin-macos-traffic-light-x relative flex min-w-0 items-center justify-between gap-3 overflow-hidden text-lg text-zinc-500 duration-200",
         shouldShowMeta && "border-border",
         className,
       )}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
In terms of social media, the height of the functional button area at the top of the details section changed from 32px to 33px, which is quite annoying. I fixed this issue by removing the 1px border at the bottom of this block.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe): 

### Screenshots (if UI change)
Before:

https://github.com/user-attachments/assets/f1a9aa29-8dd4-4ea2-b699-98b109ab0b60


After:

https://github.com/user-attachments/assets/48686d01-d68a-499f-9a1c-5f962075dca2


### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
