### PR TITLE
fix(desktop): masonry layout Slide component sometimes not working

### DIFF
--- a/apps/desktop/src/renderer/src/modules/entry-column/layouts/EntryListHeader.shared.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-column/layouts/EntryListHeader.shared.tsx
@@ -13,6 +13,7 @@ import {
   HoverCardPortal,
   HoverCardTrigger,
 } from "@radix-ui/react-hover-card"
+import { debounce } from "es-toolkit/compat"
 import type { FC } from "react"
 import * as React from "react"
 import { useTranslation } from "react-i18next"
@@ -125,9 +126,9 @@ export const SwitchToMasonryButton = () => {
                     max={6}
                     step={1}
                     defaultValue={[masonryColumnValue]}
-                    onValueCommit={(value) => {
+                    onValueChange={debounce((value) => {
                       setMasonryColumnValue(value[0]!)
-                    }}
+                    }, 300)}
                   />
                 </div>
               )}

--- a/apps/mobile/src/modules/settings/routes/ManageList.tsx
+++ b/apps/mobile/src/modules/settings/routes/ManageList.tsx
@@ -4,9 +4,7 @@ import { createContext, useContext, useEffect, useMemo, useRef, useState } from 
 import { useTranslation } from "react-i18next"
 import { PixelRatio, StyleSheet, Text, View } from "react-native"
 
-import {
-  HeaderSubmitTextButton,
-} from "@/src/components/layouts/header/HeaderElements"
+import { HeaderSubmitTextButton } from "@/src/components/layouts/header/HeaderElements"
 import {
   NavigationBlurEffectHeaderView,
   SafeNavigationScrollView,

--- a/locales/app/zh-CN.json
+++ b/locales/app/zh-CN.json
@@ -139,7 +139,7 @@
   "entry_list_header.daily_report": "每日总结",
   "entry_list_header.grid": "网格布局",
   "entry_list_header.items": "内容",
-  "entry_list_header.masonry": "砌体布局",
+  "entry_list_header.masonry": "瀑布流布局",
   "entry_list_header.masonry_column": "布局列数",
   "entry_list_header.new_entries_available": "有新内容",
   "entry_list_header.preview_mode": "预览模式",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When I adjusted the number of columns using the masonry layout, I encountered an issue where the slider movement did not take effect. I found that this has been a persistent problem with the official component's `onValueCommit` interface, which is discussed in this [issue](https://github.com/radix-ui/primitives/issues/1760). 
I tried using the stable `onValueChange` interface to configure the debounce method instead of onValueCommit. Although this eliminates a value comparison step, there is at least no difference in user experience.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)
Before:

https://github.com/user-attachments/assets/82cb75d3-d908-404c-a915-ae5e4e60af08

After:

https://github.com/user-attachments/assets/cc5f3bba-26ad-4886-93e4-82baa5b6de6f


### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
