### PR TITLE
fix(modal): remove unnecessary state update

### DIFF
--- a/apps/desktop/src/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -96,7 +96,6 @@ export const ModalInternal = memo(
       if (!CustomModalComponent) {
         dismissing().then(() => {
           setStack((p) => p.filter((modal) => modal.id !== item.id))
-          setCurrentIsClosing(false)
         })
       } else {
         nextFrame(() => {


### PR DESCRIPTION
As you can see if we update the state ourselves it will has flash on the screen.
The component will auto unmount after closing. We don't need to handle it ourselves. 



https://github.com/user-attachments/assets/ee2f7fde-447a-402c-a23a-0cf80b9aba19

