### PR TITLE
feat: Replace Cubox icon with optimized official SVG version

### DIFF
--- a/packages/components/src/ui/platform-icon/collections/cubox.tsx
+++ b/packages/components/src/ui/platform-icon/collections/cubox.tsx
@@ -6,19 +6,162 @@ export function SimpleIconsCubox({ className, ...props }: SVGProps<SVGSVGElement
     <svg
       width="1em"
       height="1em"
-      viewBox="0 0 100 100"
+      viewBox="90 41 718 718"
       xmlns="http://www.w3.org/2000/svg"
       className={cn("rounded", className)}
       {...props}
     >
-      <path d="M0 0 H100 V100 H0 Z" fill="currentColor" />
-      <path d="M10,100 A40,40 0 0,1 90,100 Z" fill="black" />
-
-      <circle cx="40" cy="75" r="8" fill="white" />
-      <circle cx="42" cy="75" r="3" fill="black" />
-
-      <circle cx="60" cy="75" r="8" fill="white" />
-      <circle cx="62" cy="75" r="3" fill="black" />
+      <defs>
+        <filter
+          id="filter0_i_1243_4043"
+          x="90"
+          y="41"
+          width="718"
+          height="718"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="81.04" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+          <feBlend mode="normal" in2="shape" result="effect1_innerShadow_1243_4043" />
+        </filter>
+        <filter
+          id="filter1_diii_1243_4043"
+          x="134.89"
+          y="298.81"
+          width="646.09"
+          height="619.03"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="-2.25" dy="-2.25" />
+          <feGaussianBlur stdDeviation="11.27" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.09 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1243_4043" />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_1243_4043"
+            result="shape"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="-59.76" dy="18.04" />
+          <feGaussianBlur stdDeviation="25.37" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.1 0" />
+          <feBlend mode="normal" in2="shape" result="effect2_innerShadow_1243_4043" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="-2.25" />
+          <feGaussianBlur stdDeviation="3.38" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.15 0" />
+          <feBlend
+            mode="normal"
+            in2="effect2_innerShadow_1243_4043"
+            result="effect3_innerShadow_1243_4043"
+          />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="26.98" dy="-69.79" />
+          <feGaussianBlur stdDeviation="18.61" />
+          <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.831373 0 0 0 0 0.854902 0 0 0 0 1 0 0 0 0.1 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="effect3_innerShadow_1243_4043"
+            result="effect4_innerShadow_1243_4043"
+          />
+        </filter>
+        <linearGradient
+          id="paint0_linear_1243_4043"
+          x1="449"
+          y1="41"
+          x2="449"
+          y2="759"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#4554FF" />
+          <stop offset="1" stopColor="#94A0F7" />
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_1243_4043"
+          x1="449"
+          y1="41"
+          x2="449"
+          y2="759"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#4554FF" />
+          <stop offset="1" stopColor="#94A0F7" />
+        </linearGradient>
+      </defs>
+      <g filter="url(#filter0_i_1243_4043)">
+        <path
+          d="M485.47 41C637.51 41 713.53 41 760.77 88.23C808 135.47 808 211.49 808 363.53V436.47C808 588.51 808 664.53 760.77 711.77C713.53 759 637.51 759 485.47 759H412.53C260.49 759 184.47 759 137.23 711.77C90 664.53 90 588.51 90 436.47V363.53C90 211.49 90 135.47 137.23 88.23C184.47 41 260.49 41 412.53 41L485.47 41Z"
+          fill="currentColor"
+        />
+      </g>
+      <mask
+        id="mask0_1243_4043"
+        style={{ maskType: "alpha" }}
+        maskUnits="userSpaceOnUse"
+        x="90"
+        y="41"
+        width="718"
+        height="718"
+      >
+        <path
+          d="M485.47 41C637.51 41 713.53 41 760.77 88.23C808 135.47 808 211.49 808 363.53V436.47C808 588.51 808 664.53 760.77 711.77C713.53 759 637.51 759 485.47 759H412.53C260.49 759 184.47 759 137.23 711.77C90 664.53 90 588.51 90 436.47V363.53C90 211.49 90 135.47 137.23 88.23C184.47 41 260.49 41 412.53 41L485.47 41Z"
+          fill="currentColor"
+        />
+      </mask>
+      <g mask="url(#mask0_1243_4043)">
+        <g filter="url(#filter1_diii_1243_4043)">
+          <path
+            d="M753.99 687.73C750.29 903.61 615.53 897.53 444.73 897.53C273.93 897.53 185.63 860.85 185.63 674.44C185.63 480.2 273.93 336.03 444.73 336.03C615.53 336.03 753.99 493.49 753.99 687.73Z"
+            fill="#02093D"
+          />
+        </g>
+        <ellipse cx="443.88" cy="554.38" rx="56.76" ry="61.73" fill="white" />
+        <ellipse cx="312.48" cy="554.38" rx="54.90" ry="61.73" fill="white" />
+        <ellipse cx="299.02" cy="554.10" rx="25.12" ry="29.46" fill="#02093D" />
+        <ellipse cx="428.56" cy="554.10" rx="25.12" ry="29.46" fill="#02093D" />
+      </g>
     </svg>
   )
 }


### PR DESCRIPTION
Replaced the Cubox icon in the project with a modified version of the official SVG.

Modifications to the official SVG include:
- Removed the "Cubox" text element.
- Removed the explicit white background element.
- Changed the icon's main background fill from the original gradient to `currentColor` for better theme adaptability.

official SVG and preview
![CleanShot 2025-04-10 at 17 08 37@2x](https://github.com/user-attachments/assets/8a6a1e0d-b181-4d0b-84ee-e87d670fc115)


![CleanShot 2025-04-10 at 18 13 09@2x](https://github.com/user-attachments/assets/c8e35a89-5995-4358-aa39-3d0c0c2af2bb)

