### PR TITLE
feat: add useBackHandler hook for handling hardware back press on And…

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -4,6 +4,7 @@ import Animated, { interpolate, useAnimatedStyle } from "react-native-reanimated
 import { RootSiblingParent } from "react-native-root-siblings"
 import { useSheet } from "react-native-sheet-transitions"
 
+import { useBackHandler } from "./hooks/useBackHandler"
 import { useIntentHandler } from "./hooks/useIntentHandler"
 import { DebugButton, EnvProfileIndicator } from "./modules/debug"
 import { usePrefetchActions } from "./store/action/hooks"
@@ -15,6 +16,7 @@ export function App({ children }: { children: React.ReactNode }) {
   useIntentHandler()
   useOnboarding()
   useUnreadCountBadge()
+  useBackHandler()
 
   // prefetch actions to detect if the user has any actions contains notifications
   usePrefetchActions()

--- a/apps/mobile/src/hooks/useBackHandler.ts
+++ b/apps/mobile/src/hooks/useBackHandler.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react"
+import { BackHandler } from "react-native"
+
+import { useCanDismiss, useNavigation } from "../lib/navigation/hooks"
+import { isAndroid } from "../lib/platform"
+
+export const useBackHandler = () => {
+  const navigation = useNavigation()
+  const canDismiss = useCanDismiss()
+
+  useEffect(() => {
+    if (!isAndroid) return
+
+    // eslint-disable-next-line @eslint-react/web-api/no-leaked-event-listener -- listener.remove() handles cleanup
+    const listener = BackHandler.addEventListener("hardwareBackPress", () => {
+      if (canDismiss) {
+        navigation.dismiss()
+      } else {
+        navigation.back()
+      }
+      return true
+    })
+
+    return () => {
+      listener.remove()
+    }
+  }, [canDismiss, navigation])
+}


### PR DESCRIPTION
This pull request introduces a new `useBackHandler` hook to manage the hardware back button behavior on Android devices.