### PR TITLE
chore(desktop): drop mark as read button in ai-daily

### DIFF
--- a/apps/desktop/src/renderer/src/modules/ai/ai-daily/daily.tsx
+++ b/apps/desktop/src/renderer/src/modules/ai/ai-daily/daily.tsx
@@ -197,15 +197,6 @@ export const DailyReportContent: Component<DailyReportContentProps> = ({
             )}
           </AutoResizeHeight>
         </ScrollArea.ScrollArea>
-        {!!content.data && (
-          <FlatMarkAllReadButton
-            className="ml-auto"
-            filter={{
-              startTime: startDate,
-              endTime: endDate,
-            }}
-          />
-        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
This button is not meaningful here. In source code, it need to get `feedId` from route, but in daily summary page we don't have this.

