### PR TITLE
fix(desktop): update isDirty prop correctly

### DIFF
--- a/apps/desktop/src/renderer/src/store/action/store.ts
+++ b/apps/desktop/src/renderer/src/store/action/store.ts
@@ -1,4 +1,5 @@
 import type { ActionModel, ActionsResponse } from "@follow/models/types"
+import { isEqual } from "es-toolkit/compat"
 
 import { apiClient } from "~/lib/api-fetch"
 
@@ -7,6 +8,7 @@ import type { ActionState } from "./types"
 
 export const useActionStore = createZustandStore<ActionState>("action")(() => ({
   actions: [],
+  originalActions: [],
   isDirty: false,
 }))
 
@@ -17,6 +19,7 @@ class ActionActionStatic {
   init(actions: ActionModel[]) {
     set((state) => {
       state.actions = actions
+      state.originalActions = structuredClone(actions)
     })
   }
 
@@ -27,21 +30,21 @@ class ActionActionStatic {
         condition: [],
         result: {},
       })
-      state.isDirty = true
+      state.isDirty = !isEqual(state.actions, state.originalActions)
     })
   }
 
   removeByIndex(index: number) {
     set((state) => {
       state.actions.splice(index, 1)
-      state.isDirty = state.actions.length > 0
+      state.isDirty = !isEqual(state.actions, state.originalActions)
     })
   }
 
   updateByIndex(index: number, update: (action: ActionModel) => void) {
     set((state) => {
       update(state.actions[index]!)
-      state.isDirty = true
+      state.isDirty = !isEqual(state.actions, state.originalActions)
     })
   }
 
@@ -92,6 +95,7 @@ class ActionActionStatic {
       },
     })
     set((state) => {
+      state.originalActions = structuredClone(get().actions)
       state.isDirty = false
     })
   }

--- a/apps/desktop/src/renderer/src/store/action/store.ts
+++ b/apps/desktop/src/renderer/src/store/action/store.ts
@@ -34,7 +34,7 @@ class ActionActionStatic {
   removeByIndex(index: number) {
     set((state) => {
       state.actions.splice(index, 1)
-      state.isDirty = true
+      state.isDirty = state.actions.length > 0
     })
   }
 

--- a/apps/desktop/src/renderer/src/store/action/types.ts
+++ b/apps/desktop/src/renderer/src/store/action/types.ts
@@ -2,5 +2,6 @@ import type { ActionModel } from "@follow/models/types"
 
 export interface ActionState {
   actions: ActionModel[]
+  originalActions: ActionModel[]
   isDirty: boolean
 }


### PR DESCRIPTION
If we add a new rule and then delete it, we actually don't have anything to save but the save button can be clicked.

https://github.com/user-attachments/assets/8f8ab51e-c8b7-480b-a702-9889fa58d93d



