### PR TITLE
fix: improve loading and preview logic in ViewSelectorRadioGroup

### DIFF
--- a/apps/desktop/src/renderer/src/modules/shared/ViewSelectorRadioGroup.tsx
+++ b/apps/desktop/src/renderer/src/modules/shared/ViewSelectorRadioGroup.tsx
@@ -19,6 +19,9 @@ export const ViewSelectorRadioGroup = forwardRef<
 >(({ entries, feed, view, className, ...rest }, ref) => {
   const t = useI18n()
 
+  const showPreview = feed && entries && entries.length > 0
+  const showLoading = !!feed && !showPreview
+
   return (
     <Card>
       <CardHeader className={cn("grid grid-cols-6 space-y-0 px-2 py-3", className)}>
@@ -53,15 +56,14 @@ export const ViewSelectorRadioGroup = forwardRef<
           </div>
         ))}
       </CardHeader>
-      {!!feed && !!entries ? (
+      {showPreview && (
         <CardContent className="space-y-2 p-2">
           {entries.slice(0, 2).map((entry) => (
             <EntryItemStateless entry={entry} feed={feed} view={view} key={entry.guid} />
           ))}
         </CardContent>
-      ) : (
-        <EntryItemSkeleton view={view ?? FeedViewType.Articles} count={2} />
       )}
+      {showLoading && <EntryItemSkeleton view={view ?? FeedViewType.Articles} count={2} />}
     </Card>
   )
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Blame to https://github.com/RSSNext/Folo/pull/3265

This pull request updates the `ViewSelectorRadioGroup` component in `ViewSelectorRadioGroup.tsx` to improve the handling of feed and entry states, ensuring clearer logic for displaying preview content or loading indicators.


### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
