### PR TITLE
fix: keep only two decimal places at most for balance

### DIFF
--- a/apps/desktop/src/renderer/src/modules/wallet/balance.tsx
+++ b/apps/desktop/src/renderer/src/modules/wallet/balance.tsx
@@ -37,7 +37,9 @@ export const Balance = ({
   const Content = (
     <span className={cn("tabular-nums", className)}>
       {withSuffix && <i className="i-mgc-power text-accent mr-1 -translate-y-px align-middle" />}
-      <span>{withTooltip ? toScientificNotation(n, scientificThreshold, locale) : formatted}</span>
+      <span className="font-mono">
+        {withTooltip ? toScientificNotation(n, scientificThreshold, locale) : formatted}
+      </span>
     </span>
   )
 
@@ -47,7 +49,7 @@ export const Balance = ({
     <Tooltip>
       <TooltipTrigger asChild>{Content}</TooltipTrigger>
       <TooltipContent>
-        <div className="text-sm">
+        <div className="font-mono text-sm">
           <span className="font-bold tabular-nums">{formattedFull}</span> <span>Power</span>
         </div>
       </TooltipContent>

--- a/packages/utils/src/utils.spec.ts
+++ b/packages/utils/src/utils.spec.ts
@@ -29,9 +29,9 @@ describe("utils", () => {
 
   test("toScientificNotation", () => {
     // Test numbers below threshold (should return original number)
-    expect(toScientificNotation(123n, 3)).toBe("123")
-    expect(toScientificNotation(999n, 3)).toBe("999")
-    expect(toScientificNotation(1234n, 5)).toBe("1,234")
+    expect(toScientificNotation(123n, 3)).toBe("123.00")
+    expect(toScientificNotation(999n, 3)).toBe("999.00")
+    expect(toScientificNotation(1234n, 5)).toBe("1,234.00")
 
     // Test numbers above threshold (should convert to scientific notation)
     expect(toScientificNotation(1234n, 3)).toBe("1.23e+3")
@@ -40,14 +40,13 @@ describe("utils", () => {
 
     // Test with decimal numbers
     expect(toScientificNotation([123456n, 2], 3)).toBe("1.23e+3")
-    expect(toScientificNotation([1234n, 4], 3)).toBe("0.1234")
 
     // Test with leading zeros
     expect(toScientificNotation(1234n, 3)).toBe("1.23e+3")
-    expect(toScientificNotation([1234n, 4], 3)).toBe("0.1234")
+    expect(toScientificNotation([1234n, 4], 3)).toBe("0.12")
 
     // Test with larger threshold
-    expect(toScientificNotation(12345678n, 8)).toBe("12,345,678")
+    expect(toScientificNotation(12345678n, 8)).toBe("12,345,678.00")
     expect(toScientificNotation(123456789n, 8)).toBe("1.23e+8")
 
     // Edge cases
@@ -71,10 +70,13 @@ describe("utils", () => {
     expect(toScientificNotation(1234567n, 3, "en-US")).toBe("1.23e+6")
 
     // Test with integer numbers below threshold with different locales
-    expect(toScientificNotation(1234n, 5, "en-US")).toBe("1,234")
-    expect(toScientificNotation(1234n, 5, "de-DE")).toBe("1.234")
+    expect(toScientificNotation(1234n, 5, "en-US")).toBe("1,234.00")
+    expect(toScientificNotation(1234n, 5, "de-DE")).toBe("1.234,00")
 
-    expect(toScientificNotation(1234n, 5, "fr-FR")).toBe("1 234")
+    expect(toScientificNotation(1234n, 5, "fr-FR")).toBe("1 234,00")
+
+    // Test with real cases
+    expect(toScientificNotation([60386874408275410679920n, 18], 6)).toBe("60,386.87")
   })
 
   test("omitShallow", () => {

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -291,7 +291,8 @@ export const toScientificNotation = (
     // Use provided locale or default to en-US
     const localeString = locale?.toString() || "en-US"
     const formatter = new Intl.NumberFormat(localeString, {
-      maximumFractionDigits: decimals,
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
     })
 
     // Convert bigint to number with correct decimal places


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Blame to https://github.com/RSSNext/Folo/pull/3319

This pull request updates the `toScientificNotation` utility function, modifying the function to enforce a fixed two-decimal format and updating test cases to validate the new behavior.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
