### PR TITLE
fix: summary syles in android

### DIFF
--- a/apps/mobile/src/modules/ai/summary.tsx
+++ b/apps/mobile/src/modules/ai/summary.tsx
@@ -16,6 +16,7 @@ import Animated, {
 import { useColor } from "react-native-uikit-colors"
 
 import { AiCuteReIcon } from "@/src/icons/ai_cute_re"
+import { isAndroid } from "@/src/lib/platform"
 
 export const AISummary: FC<{
   className?: string
@@ -63,7 +64,8 @@ export const AISummary: FC<{
     <Animated.View
       className={cn(
         "border-opaque-separator/50 mx-4 my-2 rounded-xl p-4",
-        "bg-secondary-system-background/30",
+        // Opacity modifier style incorrectly applied in Android
+        isAndroid ? "bg-secondary-system-background" : "bg-secondary-system-background/30",
         className,
       )}
       style={styles.card}


### PR DESCRIPTION
Adjust the opacity modifier for the background in the Android version of the app to ensure proper styling.


<img width="355" alt="Screenshot 2025-04-24 at 15 12 07" src="https://github.com/user-attachments/assets/71375cb3-2cd3-4a74-ab21-5c5f6a61d846" />
