### PR TITLE
fix(android): add day/night theme plugin for Android styling

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -148,6 +148,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ],
     require("./plugins/with-follow-app-delegate.js"),
     require("./plugins/with-gradle-jvm-heap-size-increase.js"),
+    require("./plugins/with-android-day-night-theme-plugin.js"),
     "expo-secure-store",
     "@react-native-firebase/app",
     "@react-native-firebase/crashlytics",

--- a/apps/mobile/plugins/with-android-day-night-theme-plugin.js
+++ b/apps/mobile/plugins/with-android-day-night-theme-plugin.js
@@ -1,0 +1,30 @@
+// Ported from https://github.com/bluesky-social/social-app/blob/a770f5635b549f2a87ffeaedd031dfe8e37b58c8/plugins/withAndroidDayNightThemePlugin.js
+// Licensed under the MIT License
+
+// Based on https://github.com/expo/expo/pull/33957
+// Could be removed once the app has been updated to Expo 53
+const { withAndroidStyles } = require("@expo/config-plugins")
+
+module.exports = function withAndroidDayNightThemePlugin(appConfig) {
+  const cleanupList = new Set([
+    "colorPrimary",
+    "android:editTextBackground",
+    "android:textColor",
+    "android:editTextStyle",
+  ])
+
+  return withAndroidStyles(appConfig, (config) => {
+    config.modResults.resources.style = config.modResults.resources.style
+      ?.map((style) => {
+        if (style.$.name === "AppTheme" && style.item != null) {
+          style.item = style.item.filter((item) => !cleanupList.has(item.$.name))
+        }
+        return style
+      })
+      .filter((style) => {
+        return style.$.name !== "ResetEditText"
+      })
+
+    return config
+  })
+}


### PR DESCRIPTION
Also related to https://github.com/nandorojo/zeego/issues/150

Introduce a plugin to support day/night theme styling for the Android app, enhancing the user interface experience.

This addition prepares the app for future updates to Expo.


<img width="251" alt="Screenshot 2025-04-24 at 16 25 37" src="https://github.com/user-attachments/assets/a9630264-cc68-46b8-849f-8e5051dbbed0" />
