### PR TITLE
feat(desktop): add copy title action and tooltip warning

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/biz/useEntryActions.tsx
+++ b/apps/desktop/src/renderer/src/hooks/biz/useEntryActions.tsx
@@ -215,7 +215,12 @@ export const useEntryActions = ({
         shortcut: shortcuts.entry.toggleStarred.key,
         entryId,
       }),
-
+      new EntryActionMenuItem({
+        id: COMMAND_ID.entry.copyTitle,
+        onClick: runCmdFn(COMMAND_ID.entry.copyTitle, [{ entryId }]),
+        shortcut: shortcuts.entry.copyTitle.key,
+        entryId,
+      }),
       new EntryActionMenuItem({
         id: COMMAND_ID.entry.copyLink,
         onClick: runCmdFn(COMMAND_ID.entry.copyLink, [{ entryId }]),

--- a/apps/desktop/src/renderer/src/modules/customize-toolbar/dnd.tsx
+++ b/apps/desktop/src/renderer/src/modules/customize-toolbar/dnd.tsx
@@ -1,9 +1,18 @@
 import type { UniqueIdentifier } from "@dnd-kit/core"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from "@follow/components/ui/tooltip/index.js"
+import { IN_ELECTRON } from "@follow/shared"
 import type { ReactNode } from "react"
 import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
 
+import { COMMAND_ID } from "../command/commands/id"
 import { getCommand } from "../command/hooks/use-command"
 import type { FollowCommandId } from "../command/types"
 
@@ -40,8 +49,14 @@ const SortableItem = ({ id, children }: { id: UniqueIdentifier; children: ReactN
   )
 }
 
+const warningActionButton: Partial<Record<FollowCommandId, string>> = {
+  [COMMAND_ID.entry.tts]: "entry_actions.warn_info_for_desktop",
+}
+
 export const SortableActionButton = ({ id }: { id: UniqueIdentifier }) => {
   const cmd = getCommand(id as FollowCommandId)
+  const warnInfo = warningActionButton[id as FollowCommandId]
+  const { t } = useTranslation()
   if (!cmd) return null
   return (
     <SortableItem id={id}>
@@ -50,6 +65,16 @@ export const SortableActionButton = ({ id }: { id: UniqueIdentifier }) => {
           {typeof cmd.icon === "function" ? cmd.icon({ isActive: false }) : cmd.icon}
         </div>
         <div className="mt-1 text-center text-xs text-neutral-500 dark:text-neutral-400">
+          {!IN_ELECTRON && warnInfo && (
+            <Tooltip>
+              <TooltipTrigger>
+                <i className="i-mgc-information-cute-re mr-1 translate-y-[2px]" />
+              </TooltipTrigger>
+              <TooltipPortal>
+                <TooltipContent>{t(warnInfo as any)}</TooltipContent>
+              </TooltipPortal>
+            </Tooltip>
+          )}
           {cmd.label.title}
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/modules/customize-toolbar/dnd.tsx
+++ b/apps/desktop/src/renderer/src/modules/customize-toolbar/dnd.tsx
@@ -49,8 +49,19 @@ const SortableItem = ({ id, children }: { id: UniqueIdentifier; children: ReactN
   )
 }
 
-const warningActionButton: Partial<Record<FollowCommandId, string>> = {
-  [COMMAND_ID.entry.tts]: "entry_actions.warn_info_for_desktop",
+const warningActionButton: Partial<
+  Record<
+    FollowCommandId,
+    {
+      show: boolean
+      info: string
+    }
+  >
+> = {
+  [COMMAND_ID.entry.tts]: {
+    show: !IN_ELECTRON,
+    info: "entry_actions.warn_info_for_desktop",
+  },
 }
 
 export const SortableActionButton = ({ id }: { id: UniqueIdentifier }) => {
@@ -65,13 +76,13 @@ export const SortableActionButton = ({ id }: { id: UniqueIdentifier }) => {
           {typeof cmd.icon === "function" ? cmd.icon({ isActive: false }) : cmd.icon}
         </div>
         <div className="mt-1 text-center text-xs text-neutral-500 dark:text-neutral-400">
-          {!IN_ELECTRON && warnInfo && (
+          {warnInfo?.show && (
             <Tooltip>
               <TooltipTrigger>
                 <i className="i-mgc-information-cute-re mr-1 translate-y-[2px]" />
               </TooltipTrigger>
               <TooltipPortal>
-                <TooltipContent>{t(warnInfo as any)}</TooltipContent>
+                <TooltipContent>{t(warnInfo.info as any)}</TooltipContent>
               </TooltipPortal>
             </Tooltip>
           )}

--- a/locales/app/en.json
+++ b/locales/app/en.json
@@ -124,6 +124,7 @@
   "entry_actions.unstar": "Unstar",
   "entry_actions.unstarred": "Unstarred.",
   "entry_actions.view_source_content": "View Source Content",
+  "entry_actions.warn_info_for_desktop": "This feature is only available in the desktop app",
   "entry_column.filtered_content_tip": "You have filtered content hidden.",
   "entry_column.filtered_content_tip_2": "In addition to the entries shown above, there is also filtered content.",
   "entry_column.refreshing": "Refreshing new entries...",

--- a/locales/app/zh-CN.json
+++ b/locales/app/zh-CN.json
@@ -123,6 +123,7 @@
   "entry_actions.unstar": "取消收藏",
   "entry_actions.unstarred": "取消收藏",
   "entry_actions.view_source_content": "查看原文",
+  "entry_actions.warn_info_for_desktop": "此功能只在桌面端可用",
   "entry_column.filtered_content_tip": "部分内容已被过滤隐藏。",
   "entry_column.filtered_content_tip_2": "除了上面显示的内容外，还有一些被过滤的内容。",
   "entry_column.refreshing": "正在刷新",


### PR DESCRIPTION
1. `copyTitle` action is missing in header actions. 

Close: #3569

After:

![CleanShot 2025-04-25 at 10 15 41](https://github.com/user-attachments/assets/e7b0bc27-736e-429f-a6e4-3a1e7121ebbe)


2.  For `tts`, it is hiden in browser or mobile. But it exists in custom toolbar, so I add a tip here.

<img src="https://github.com/user-attachments/assets/5e62df13-4c72-4734-8f7c-a0c420e2bcd3" width="500" />