### PR TITLE
fix(desktop): add z-index to close button for proper stacking

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/discover/recommendations.tsx
+++ b/apps/desktop/layer/renderer/src/modules/discover/recommendations.tsx
@@ -230,7 +230,7 @@ const RecommendationDrawerContent = ({
 
       {/* Close */}
       <ActionButton
-        className="absolute right-4 top-4"
+        className="absolute right-4 top-4 z-10"
         onClick={dismiss}
         tooltip={t("words.close", { ns: "common" })}
       >


### PR DESCRIPTION
The close btn is covered by content.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/32694b7d-57d7-4361-a690-acdfb2ab4a07" />
