### PR TITLE
fix(desktop): preview feature is invaliable in discover

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/discover/DiscoverFeedForm.tsx
+++ b/apps/desktop/layer/renderer/src/modules/discover/DiscoverFeedForm.tsx
@@ -287,6 +287,10 @@ export const DiscoverFeedForm = ({
                       formRegister.onBlur(e)
                     })
                   }}
+                  onChange={(e) => {
+                    form.setValue(keyItem.name, e.target.value)
+                  }}
+                  defaultValue={parameters?.default ?? ""}
                   placeholder={
                     (parameters?.default ?? formPlaceholder[keyItem.name])
                       ? `e.g. ${formPlaceholder[keyItem.name]}`


### PR DESCRIPTION
When I add a new feed and click the preview button, nothing occurs. It claims I failed to enter the parameter, yet in reality, I have indeed provided it.

I discover that the input field does not properly bind to the value change event.

Before:

<img width="622" alt="image" src="https://github.com/user-attachments/assets/08bb8f35-b68a-4251-8937-c89bf6baf9f4" />


After:

https://github.com/user-attachments/assets/50f51c85-d292-4e2b-87b7-ef56e76677a9

