### PR TITLE
fix(desktop): EntryList Component keep scroll position is inaccurate

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/list.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/list.tsx
@@ -114,24 +114,25 @@ export const EntryList: FC<EntryListProps> = memo(
       [groupCounts],
     )
 
+    const cacheKey = `${view}-${feedId}`
     const rowVirtualizer = useVirtualizer({
       count: entriesIds.length + 1,
       estimateSize: () => 112,
       overscan: 5,
       gap,
       getScrollElement: () => scrollRef,
-      initialOffset: offsetCache.get(feedId) ?? 0,
-      initialMeasurementsCache: measurementsCache.get(feedId) ?? [],
+      initialOffset: offsetCache.get(cacheKey) ?? 0,
+      initialMeasurementsCache: measurementsCache.get(cacheKey) ?? [],
       onChange: useTypeScriptHappyCallback(
         (virtualizer: Virtualizer<HTMLElement, Element>) => {
           if (!virtualizer.isScrolling) {
-            measurementsCache.put(feedId, virtualizer.measurementsCache)
-            offsetCache.put(feedId, virtualizer.scrollOffset ?? 0)
+            measurementsCache.put(cacheKey, virtualizer.measurementsCache)
+            offsetCache.put(cacheKey, virtualizer.scrollOffset ?? 0)
           }
 
           onRangeChange?.(virtualizer.range as Range)
         },
-        [feedId],
+        [cacheKey],
       ),
       rangeExtractor: useTypeScriptHappyCallback(
         (range: Range) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
before:

https://github.com/user-attachments/assets/d631e2cb-b6ae-42ab-bb08-f2d25fb16fb4


after:

https://github.com/user-attachments/assets/8ee0890c-eb62-4891-9893-8ba0563d81fd

<img width="683" alt="image" src="https://github.com/user-attachments/assets/2495ad12-f30a-4fb4-ab23-51140ba4f80c" />

 ⬆️  In the above code, feedId is used as the key to save the offset value. However, if change the feed view in Header, the feedId will be 'all', always 'all', so, In this situation, keep scroll position is inaccurate
my solution is to change the key to use `${view}-${feedId}`

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
