### PR TITLE
fix: handle Hugo code block workaround

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/code-highlighter/shiki/Shiki.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/code-highlighter/shiki/Shiki.tsx
@@ -27,6 +27,7 @@ export interface ShikiProps {
   className?: string
 
   transparent?: boolean
+  showCopy?: boolean
 
   theme?: string
 }
@@ -158,7 +159,7 @@ const ShikiCode: FC<
   ShikiProps & {
     codeTheme: string
   }
-> = ({ code, language, codeTheme, className, transparent }) => {
+> = ({ code, language, codeTheme, className, transparent, showCopy = true }) => {
   const rendered = useMemo(() => {
     try {
       return shiki.codeToHtml(code, {
@@ -198,7 +199,7 @@ const ShikiCode: FC<
             <span>{language}</span>
           </span>
         )}
-        <CopyButton variant="outline" value={code} />
+        <CopyButton variant="outline" value={code} className={showCopy ? "" : "invisible"} />
       </div>
       <div dangerouslySetInnerHTML={{ __html: rendered }} data-language={language} />
     </div>

--- a/apps/desktop/layer/renderer/src/lib/parse-html.ts
+++ b/apps/desktop/layer/renderer/src/lib/parse-html.ts
@@ -147,10 +147,14 @@ export const parseHtml = (
         }
 
         if (!codeString) return createElement("pre", props, props.children)
+        // Workaround for Hugo's code block
+        // Code line number in Hugo will render inside <pre> tag
+        const isLineNumberInHugo = codeString.slice(0, 15).split(" ").join("").startsWith("1\n2\n3")
 
         return createElement(ShikiHighLighter, {
           code: codeString.trimEnd(),
           language: language.toLowerCase(),
+          showCopy: !isLineNumberInHugo,
         })
       },
       figure: ({ node, ...props }) =>
@@ -173,6 +177,9 @@ export const parseHtml = (
             className: tw`w-full my-0`,
           }),
         ),
+      td: ({ node, ...props }) =>
+        // Workaround for Hugo's table code
+        createElement("td", { ...props, className: tw`p-0` }, props.children),
     },
   })
 }


### PR DESCRIPTION
Implement a workaround for Hugo's code block rendering issues, ensuring proper handling of line numbers and visibility of the copy button in the code highlighter.

Related entry https://app.follow.is/timeline/view-0/140318102626016256/140318102651182082

Before

![image](https://github.com/user-attachments/assets/b6d32402-ec32-434a-a640-b674dc085a46)


After

<img width="758" alt="Screenshot 2025-05-02 at 04 14 28" src="https://github.com/user-attachments/assets/af0dd4f6-0b73-428d-99a8-afaae04f0188" />
