### PR TITLE
fix(grid-entry): fix rowVirtualizer not proper refresh when view change

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
@@ -178,7 +178,6 @@ const VirtualGridImpl: FC<
   })
 
   useEffect(() => {
-    rowVirtualizer.measure()
     if (!listRef) return
     listRef.current = rowVirtualizer
   }, [rowVirtualizer, listRef])
@@ -188,6 +187,7 @@ const VirtualGridImpl: FC<
       rowVirtualizer.measure()
       columnVirtualizer.measure()
     }
+    measureRef.current?.()
   }, [columnVirtualizer, measureRef, rowVirtualizer])
 
   const virtualItems = rowVirtualizer.getVirtualItems()

--- a/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
@@ -178,6 +178,7 @@ const VirtualGridImpl: FC<
   })
 
   useEffect(() => {
+    rowVirtualizer.measure()
     if (!listRef) return
     listRef.current = rowVirtualizer
   }, [rowVirtualizer, listRef])


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

- before:

  - video to picture:

  picture was squeezed together.

  https://github.com/user-attachments/assets/402d3c36-72b8-422a-8d47-d80dc1917541

  - picture to video:

  the gap for video is so big.

  https://github.com/user-attachments/assets/be7f0532-8e89-4c5f-9ac5-a10c7315c7c4

- after:

  now should looks fine 😄 

  https://github.com/user-attachments/assets/6e3bf1e0-4999-4876-b4a8-fed9f51277b0

### Linked Issues

related to #2573

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
