### PR TITLE
fix(desktop): font names that include whitespace must be quoted

### DIFF
--- a/apps/desktop/layer/renderer/src/providers/setting-sync.tsx
+++ b/apps/desktop/layer/renderer/src/providers/setting-sync.tsx
@@ -24,11 +24,7 @@ const useUISettingSync = () => {
   useInsertionEffect(() => {
     const root = document.documentElement
     // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#valid_family_names
-    const fontFamily = setting.uiFontFamily.includes(" ")
-      ? `"${setting.uiFontFamily}"`
-      : setting.uiFontFamily
-
-    const fontCss = `${fontFamily}, system-ui, sans-serif`
+    const fontCss = `"${setting.uiFontFamily}", system-ui, sans-serif`
 
     Object.assign(root.style, {
       fontFamily: fontCss,

--- a/apps/desktop/layer/renderer/src/providers/setting-sync.tsx
+++ b/apps/desktop/layer/renderer/src/providers/setting-sync.tsx
@@ -23,8 +23,13 @@ const useUISettingSync = () => {
 
   useInsertionEffect(() => {
     const root = document.documentElement
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#valid_family_names
+    const fontFamily = setting.uiFontFamily.includes(" ")
+      ? `"${setting.uiFontFamily}"`
+      : setting.uiFontFamily
 
-    const fontCss = `${setting.uiFontFamily},"SN Pro", system-ui, sans-serif`
+    const fontCss = `${fontFamily}, system-ui, sans-serif`
+
     Object.assign(root.style, {
       fontFamily: fontCss,
     })


### PR DESCRIPTION
Close: #3622

Font family names that include whitespace or other special characters (like &, !, #) must be quoted. For example, "Times New Roman" or 'Arial Black'.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#valid_family_names
