### PR TITLE
fix: prevent event propagation on double click for navigation buttons…

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/media/SwipeMedia.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/SwipeMedia.tsx
@@ -1,4 +1,5 @@
 import type { MediaModel } from "@follow/shared/hono"
+import { stopPropagation } from "@follow/utils/dom"
 import { cn } from "@follow/utils/utils"
 import useEmblaCarousel from "embla-carousel-react"
 import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures"
@@ -84,6 +85,7 @@ export function SwipeMedia({
               type="button"
               className="center absolute left-2 top-1/2 size-6 -translate-y-1/2 rounded-full bg-gray-800 text-white opacity-0 duration-200 group-hover:opacity-100"
               onClick={scrollPrev}
+              onDoubleClick={stopPropagation}
             >
               <i className="i-mingcute-arrow-left-line" />
             </button>
@@ -93,6 +95,7 @@ export function SwipeMedia({
               type="button"
               className="center absolute right-2 top-1/2 size-6 -translate-y-1/2 rounded-full bg-gray-800 text-white opacity-0 duration-200 group-hover:opacity-100"
               onClick={scrollNext}
+              onDoubleClick={stopPropagation}
             >
               <i className="i-mingcute-arrow-right-line" />
             </button>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue in the SwipeMedia component where double-clicking the previous/next buttons would trigger the parent’s navigation behavior.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)
![1](https://private-user-images.githubusercontent.com/107846196/414513438-5a81d0a2-9a31-47d8-8269-c0b29d0310eb.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDcyOTUyMzIsIm5iZiI6MTc0NzI5NDkzMiwicGF0aCI6Ii8xMDc4NDYxOTYvNDE0NTEzNDM4LTVhODFkMGEyLTlhMzEtNDdkOC04MjY5LWMwYjI5ZDAzMTBlYi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNTE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDUxNVQwNzQyMTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01YWIwNjE5MzZiMjE2ZTlkZmYzZGJkZDBmOTlkYTI4ZjY1MGZjY2Y2NGZlZjkxYmM1YWM3YjExNTE3ZDhiNmJlJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.9iB95jkcIlhKWgxIcfOWL8WAaG6jRaZ-LfYVvL581qI)

### Demo Video (if new feature)

### Linked Issues
#2804

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
