### PR TITLE
fix: add video support in entry content

### DIFF
--- a/apps/mobile/src/components/native/webview/native-webview.android.tsx
+++ b/apps/mobile/src/components/native/webview/native-webview.android.tsx
@@ -50,8 +50,9 @@ export const NativeWebView: React.ComponentType<
       sharedCookiesEnabled
       originWhitelist={["*"]}
       allowUniversalAccessFromFileURLs
-      startInLoadingState
+      // startInLoadingState
       allowsBackForwardNavigationGestures
+      allowsFullscreenVideo
       injectedJavaScriptBeforeContentLoaded={atStart}
       onNavigationStateChange={onNavigationStateChange}
       onLoadEnd={useCallback(() => {

--- a/apps/mobile/web-app/html-renderer/src/parser.tsx
+++ b/apps/mobile/web-app/html-renderer/src/parser.tsx
@@ -148,6 +148,11 @@ export const parseHtml = (
             className: tw`w-full my-0`,
           }),
         ),
+      video: ({ node, ...props }) =>
+        createElement("video", {
+          ...props,
+          controls: true,
+        }),
     },
   })
 }


### PR DESCRIPTION
Enable fullscreen video in the NativeWebView and add support for video components with controls in the HTML parser.