### PR TITLE
fix(discover): borken style in discover page

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/discover/DiscoverFeedCard.tsx
+++ b/apps/desktop/layer/renderer/src/modules/discover/DiscoverFeedCard.tsx
@@ -103,24 +103,22 @@ export const DiscoverFeedCard: FC<DiscoverFeedCardProps> = memo(
       <Card
         data-feed-id={item.feed?.id || item.list?.id}
         className={cn(
-          "select-text overflow-hidden rounded-b-none border-0 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl transition-all duration-300 dark:border-zinc-800/50 dark:bg-neutral-800/50",
+          "select-text overflow-hidden border border-zinc-200/50 bg-white/80 backdrop-blur-xl transition-all duration-300 dark:border-zinc-800/50 dark:bg-neutral-800/50",
           className,
         )}
       >
-        <CardHeader className="p-0 pb-2">
+        <CardHeader className="p-4 pb-2">
           <FollowSummary feed={item.feed || item.list!} docs={item.docs} />
         </CardHeader>
-        {item.docs ? (
-          <CardContent className="p-0">
+        <CardContent className="px-4">
+          {item.docs ? (
             <a href={item.docs} target="_blank" rel="noreferrer">
               <Button buttonClassName="rounded-full bg-zinc-900 px-6 text-white transition-opacity hover:opacity-90 dark:bg-white dark:text-zinc-900">
                 View Docs
               </Button>
             </a>
-          </CardContent>
-        ) : (
-          <>
-            <CardContent className="p-0">
+          ) : (
+            <>
               {!!item.entries?.length && (
                 <div className="mt-2">
                   <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
@@ -132,7 +130,7 @@ export const DiscoverFeedCard: FC<DiscoverFeedCardProps> = memo(
                   </div>
                 </div>
               )}
-              <div className="mt-2 flex justify-between gap-4">
+              <div className="mt-4 flex justify-between gap-4">
                 <div className="text-text-secondary flex items-center gap-3 text-sm">
                   {!!item.analytics?.subscriptionCount && (
                     <div className="flex items-center gap-1.5">
@@ -162,12 +160,11 @@ export const DiscoverFeedCard: FC<DiscoverFeedCardProps> = memo(
                     </div>
                   ) : null}
                 </div>
-
                 <FeedCardActions item={item} onSuccess={onSuccess} isSubscribed={isSubscribed} />
               </div>
-            </CardContent>
-          </>
-        )}
+            </>
+          )}
+        </CardContent>
       </Card>
     )
   },

--- a/apps/desktop/layer/renderer/src/modules/discover/DiscoverForm.tsx
+++ b/apps/desktop/layer/renderer/src/modules/discover/DiscoverForm.tsx
@@ -302,14 +302,14 @@ export function DiscoverForm({ type = "search" }: { type?: string }) {
               </MotionButtonBase>
             )}
           </div>
-          <div className="text-sm">
+          <div className="space-y-4 text-sm">
             {discoverSearchData?.map((item) => (
               <DiscoverFeedCard
                 key={item.feed?.id || item.list?.id}
                 item={item}
                 onSuccess={handleSuccess}
                 onUnSubscribed={handleUnSubscribed}
-                className="py-5 last:border-b-0"
+                className="last:border-b-0"
               />
             ))}
           </div>


### PR DESCRIPTION
I only check  `DiscoverFeedCard` for the discover page . I don't know if there are any effects to other pages.

| Before | After |
| --- | ---- |
| <img src="https://github.com/user-attachments/assets/5fbe3119-c408-462f-be4e-4d6d34e0f355" /> | <img src="https://github.com/user-attachments/assets/83f120c9-6eaf-465b-9bdc-bb91ba94b44b" /> |

