### PR TITLE
feat(desktop): enhance behavior of scroll progress component

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/app-layout/subview/index.electron.tsx
+++ b/apps/desktop/layer/renderer/src/modules/app-layout/subview/index.electron.tsx
@@ -171,12 +171,17 @@ const SubViewHeaderRightView = () => {
   return <div className="inline-flex items-center">{rightView}</div>
 }
 
-const ScrollProgressFAB = ({ scrollY, scrollRef }: { scrollY: number; scrollRef: any }) => {
+const ScrollProgressFAB = ({
+  scrollY,
+  scrollRef,
+}: {
+  scrollY: number
+  scrollRef: HTMLDivElement | null
+}) => {
   const [maxScroll, setMaxScroll] = useState(0)
-  const location = useLocation()
 
   useEffect(() => {
-    if (!scrollRef) return
+    if (!scrollRef || scrollY <= 100) return
 
     const updateMaxScroll = () => {
       const { scrollHeight, clientHeight } = scrollRef
@@ -188,7 +193,7 @@ const ScrollProgressFAB = ({ scrollY, scrollRef }: { scrollY: number; scrollRef:
     resizeObserver.observe(scrollRef)
 
     return () => resizeObserver.disconnect()
-  }, [location.pathname, scrollRef])
+  }, [scrollRef, scrollY])
 
   const progress = maxScroll > 0 ? Math.min(100, (scrollY / maxScroll) * 100) : 0
   const showProgress = scrollY > 100 && maxScroll > 100
@@ -228,7 +233,7 @@ const ScrollProgressFAB = ({ scrollY, scrollRef }: { scrollY: number; scrollRef:
         </div>
         <button
           onClick={() => {
-            springScrollTo(0, scrollRef)
+            springScrollTo(0, scrollRef ?? document.documentElement)
           }}
           type="button"
           className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-200 group-hover/fab:opacity-100"

--- a/packages/internal/utils/src/scroller.ts
+++ b/packages/internal/utils/src/scroller.ts
@@ -13,7 +13,7 @@ export const springScrollTo = (
   y: number,
   scrollerElement: HTMLElement = document.documentElement,
 ) => {
-  const scrollTop = scrollerElement?.scrollTop
+  const { scrollTop } = scrollerElement
 
   let isStop = false
   const stopSpringScrollHandler = () => {


### PR DESCRIPTION
Since trending content is lazily loaded, `maxScroll` initially reflects an incorrect value. To ensure accuracy, we must recompute `maxScroll` upon the scroll progress component’s visibility.

But it's not the best solution. 😢