### PR TITLE
fix(link): fix link start with '.' don't handle proper

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/renderer/html.tsx
+++ b/apps/desktop/layer/renderer/src/modules/renderer/html.tsx
@@ -39,8 +39,11 @@ export function EntryContentHTMLRenderer<AS extends keyof JSX.IntrinsicElements 
         {} as Record<string, MarkdownImage>,
       ) ?? {}
 
+    const { url } = state
+
     return {
       images,
+      url,
     }
   })
 
@@ -52,16 +55,21 @@ export function EntryContentHTMLRenderer<AS extends keyof JSX.IntrinsicElements 
       },
       transformUrl(url) {
         if (!url || url.startsWith("http")) return url
+
         const feed = getFeedById(feedId)
         if (!feed) return url
-        const feedSiteUrl = "siteUrl" in feed ? feed.siteUrl : undefined
 
+        const feedSiteUrl = "siteUrl" in feed ? feed.siteUrl : undefined
         if (url.startsWith("/") && feedSiteUrl) return safeUrl(url, feedSiteUrl)
+
+        const entryUrl = entry?.url
+        if (url?.startsWith(".") && entryUrl) return safeUrl(url, entryUrl)
+
         return url
       },
       ensureAndRenderTimeStamp,
     }
-  }, [feedId, view])
+  }, [entry, feedId, view])
   return (
     // eslint-disable-next-line @eslint-react/no-context-provider
     <MarkdownImageRecordContext.Provider value={images}>

--- a/apps/desktop/layer/renderer/src/modules/renderer/html.tsx
+++ b/apps/desktop/layer/renderer/src/modules/renderer/html.tsx
@@ -57,13 +57,9 @@ export function EntryContentHTMLRenderer<AS extends keyof JSX.IntrinsicElements 
         if (!url || url.startsWith("http")) return url
 
         const feed = getFeedById(feedId)
-        if (!feed) return url
+        if (url.startsWith("/") && feed?.siteUrl) return safeUrl(url, feed.siteUrl)
 
-        const feedSiteUrl = "siteUrl" in feed ? feed.siteUrl : undefined
-        if (url.startsWith("/") && feedSiteUrl) return safeUrl(url, feedSiteUrl)
-
-        const entryUrl = entry?.url
-        if (url?.startsWith(".") && entryUrl) return safeUrl(url, entryUrl)
+        if (url?.startsWith(".") && entry?.url) return safeUrl(url, entry?.url)
 
         return url
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I use relative path in my blog writing, it start with `.` such like:

```html
<a href="../some-magic-connections">some text</a>
```

but folo can't handle proper, like this:

![image](https://github.com/user-attachments/assets/3c8af8d2-8798-4618-ba3e-170e0a953b44)

![image](https://github.com/user-attachments/assets/726b7617-044c-46c7-8b1a-6fb38f579a42)



After fix, now should look better:

![image](https://github.com/user-attachments/assets/22ac24d0-90bb-4e5a-b292-01a7be25a612)

I also find the latest code can't run in browser, so i temporarily set my dev branch to server days ago, to avoid it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
