### PR TITLE
fix: fix social media click Read more refresh

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
@@ -519,7 +519,7 @@ const FallbackableImage: FC<
       )}
 
       {currentState === "fallback" && (
-        <div className="bg-material-thick backdrop-blur-background text-text absolute bottom-8 left-1/2 mt-4 -translate-x-1/2 rounded-lg px-3 py-2 text-center text-xs">
+        <div className="bg-material-thick backdrop-blur-background text-text absolute bottom-8 left-1/2 mt-4 -translate-x-1/2 rounded-lg px-3 py-2 text-center text-xs opacity-70">
           <span>
             This image is preview in low quality, because the original image is not available.
           </span>

--- a/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
@@ -217,7 +217,7 @@ export function SocialMediaItemStateLess({ entry, feed }: EntryItemStatelessProp
   )
 }
 
-export const SocialMediaItemSkeleton = () => (
+export const SocialMediaItemSkeleton = (
   <div className="relative m-auto w-[645px] rounded-md">
     <div className="relative">
       <div className="group relative flex px-8 py-6">

--- a/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
@@ -217,7 +217,7 @@ export function SocialMediaItemStateLess({ entry, feed }: EntryItemStatelessProp
   )
 }
 
-export const SocialMediaItemSkeleton = (
+export const SocialMediaItemSkeleton = () => (
   <div className="relative m-auto w-[645px] rounded-md">
     <div className="relative">
       <div className="group relative flex px-8 py-6">
@@ -420,6 +420,7 @@ const CollapsedSocialMediaItem: Component<{
           <button
             type="button"
             onClick={(e) => {
+              e.preventDefault()
               e.stopPropagation()
               setIsShowMore(true)
               collapsedItemCache.put(entryId, true)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR contain two changes:

- because the 'read more' button in social-media is contained by a `<a>` tag, maybe this will cause a refresh? (i can't make sure, because dev version not refresh, but release version refresh, require further discussion, this is related to #4006 ), and change `SocialMediaItemSkeleton` to function component.

- add opacity for preview-media message, see picture:

![image](https://github.com/user-attachments/assets/e04afce1-17f7-44b3-a119-8bdd3234dc59)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
