### PR TITLE
feat: support Android adaptive icon

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -63,6 +63,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       edgeToEdgeEnabled: true,
       adaptiveIcon: {
         foregroundImage: adaptiveIconPath,
+        monochromeImage: adaptiveIconPath,
         backgroundColor: "#FF5C00",
       },
       googleServicesFile: "./build/google-services.json",


### PR DESCRIPTION
Fix https://github.com/RSSNext/Folo/issues/3908

Implement support for Android adaptive icons by adding a monochrome image option in the app configuration.

Learn more: https://docs.expo.dev/develop/user-interface/splash-screen-and-app-icon/#android

![image](https://github.com/user-attachments/assets/5391209b-aada-485b-93e4-ee35859bd77b)
