### PR TITLE
feat(desktop): only approve download in desktop not website

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
@@ -6,6 +6,7 @@ import {
   TooltipPortal,
   TooltipTrigger,
 } from "@follow/components/ui/tooltip/index.js"
+import { IN_ELECTRON } from "@follow/shared/constants"
 import type { MediaModel } from "@follow/shared/hono"
 import { stopPropagation } from "@follow/utils/dom"
 import { cn } from "@follow/utils/utils"
@@ -21,6 +22,7 @@ import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch"
 
 import { m } from "~/components/common/Motion"
 import { COPY_MAP } from "~/constants"
+import { ipcServices } from "~/lib/client"
 import { replaceImgUrlIfNeed } from "~/lib/img-proxy"
 
 import { useCurrentModal } from "../modal/stacked/hooks"
@@ -202,19 +204,16 @@ const HeaderActions: FC<{
       <HeaderButton description={t(COPY_MAP.OpenInBrowser())} onClick={() => window.open(src)}>
         <i className="i-mgc-external-link-cute-re" />
       </HeaderButton>
-      <HeaderButton
-        description={t("common:words.download")}
-        onClick={() => {
-          const a = document.createElement("a")
-          a.href = src
-          a.download = src.split("/").pop()!
-          a.target = "_blank"
-          a.rel = "noreferrer"
-          a.click()
-        }}
-      >
-        <i className="i-mgc-download-2-cute-re" />
-      </HeaderButton>
+      {IN_ELECTRON && (
+        <HeaderButton
+          description={t("common:words.download")}
+          onClick={() => {
+            ipcServices?.app.download(src)
+          }}
+        >
+          <i className="i-mgc-download-2-cute-re" />
+        </HeaderButton>
+      )}
 
       <HeaderButton
         description={t("common:words.close")}


### PR DESCRIPTION
Close: #4084 

It seems don't want to have a download button in website.

https://github.com/RSSNext/Folo/commit/cf72753b590b3197c0a9cc7f2b44c411efc72e08#diff-f20c78d077ecc258ffb0acd961771b6bfe4f0248b4972deb340c5adfd7e4edb4L113-L122

<img src="https://github.com/user-attachments/assets/9c2aba72-be68-4561-bc3b-5bfd79346f6c" width="500" />
