### PR TITLE
fix(desktop): prevent feed click event from bubbling to route item

### DIFF
--- a/apps/desktop/layer/renderer/src/pages/(main)/(layer)/(subview)/discover/category/[category].tsx
+++ b/apps/desktop/layer/renderer/src/pages/(main)/(layer)/(subview)/discover/category/[category].tsx
@@ -381,7 +381,13 @@ const RouteItem = memo(
                     className="mask-squircle mask shrink-0 rounded-none"
                     size={16}
                   />
-                  <div className="min-w-0 leading-tight" onClick={() => onFeedClick(feed.id)}>
+                  <div
+                    className="min-w-0 leading-tight"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onFeedClick(feed.id)
+                    }}
+                  >
                     <EllipsisHorizontalTextWithTooltip className="truncate">
                       {getPreferredTitle(feed) || feed?.title}
                     </EllipsisHorizontalTextWithTooltip>


### PR DESCRIPTION
| Before | After |
| --- | ---- |
| ![CleanShot 2025-07-08 at 23 06 04](https://github.com/user-attachments/assets/4e2c7c7c-73a1-444a-8bd8-46974e017c03) | ![CleanShot 2025-07-08 at 23 05 41](https://github.com/user-attachments/assets/770b1e1f-5bd1-4859-8249-b753ce3a6a61) |
