### PR TITLE
revert: social media link click logic

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/Items/social-media-item.tsx
@@ -385,7 +385,6 @@ const CollapsedSocialMediaItem: Component<{
           <button
             type="button"
             onClick={(e) => {
-              e.preventDefault()
               e.stopPropagation()
               setIsShowMore(true)
               collapsedItemCache.put(entryId, true)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Reverting #4027 since the original issue was actually fixed in [this commit](https://github.com/RSSNext/Folo/commit/0f656d5ca3f7829f01d1f9cb1cb82e547ce4a8ad). #4027 caused links in Social-Media view no longer open in a new tab. Sorry for the mistake!