### PR TITLE
fix: fix Audio item layout

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/Items/audio-item.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/Items/audio-item.tsx
@@ -5,11 +5,14 @@ import { Media } from "~/components/ui/media/Media"
 import { ListItem } from "~/modules/entry-column/templates/list-item-template"
 import { FeedTitle } from "~/modules/feed/feed-title"
 
+import { readableContentMaxWidth } from "../styles"
 import type { EntryItemStatelessProps, UniversalItemProps } from "../types"
 
 export function AudioItem({ entryId, entryPreview, translation }: UniversalItemProps) {
   return <ListItem entryId={entryId} entryPreview={entryPreview} translation={translation} />
 }
+
+AudioItem.wrapperClassName = readableContentMaxWidth
 
 export function AudioItemStateLess({ entry, feed }: EntryItemStatelessProps) {
   return (


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

in https://github.com/RSSNext/Folo/commit/0e456d5b7368bbc050e75bd580266f13fb62d016#diff-d6734654ec584a44e9347c866aecae2779274875017377b9a5cc534138cff4fe the Audio item was not add corresponding style, cause not enough padding, This PR fix it.

Before：

<img width="627" height="317" alt="image" src="https://github.com/user-attachments/assets/205d99f3-a8ff-4d9c-9682-6b9e38475b6d" />

After:

<img width="615" height="317" alt="image" src="https://github.com/user-attachments/assets/c8c5ef4a-ce8c-410f-9542-3ed6573fd368" />
