### PR TITLE
fix: implement edge touch prevention for context menu on Android

### DIFF
--- a/apps/mobile/src/components/ui/context-menu/index.tsx
+++ b/apps/mobile/src/components/ui/context-menu/index.tsx
@@ -1,5 +1,7 @@
+import { useTypeScriptHappyCallback } from "@follow/hooks"
 import { composeEventHandlers } from "@follow/utils"
-import { Vibration } from "react-native"
+import { useState } from "react"
+import { Dimensions, Vibration } from "react-native"
 import * as ZeegoContextMenu from "zeego/context-menu"
 
 import { isAndroid } from "@/src/lib/platform"
@@ -27,6 +29,40 @@ const ContextMenuRoot: typeof ZeegoContextMenu.Root = (props) => {
 const ContextMenu = {
   ...ZeegoContextMenu,
   Root: ContextMenuRoot,
+}
+
+const MAGIC = "none"
+export const usePreventContextMenuOnEdge = (): Parameters<typeof ZeegoContextMenu.Trigger>[0] => {
+  const [disableContextMenu, setDisableContextMenu] = useState(false)
+  const contextMenuHandlerProps = {
+    // @ts-expect-error -- See https://zeego.dev/components/context-menu#trigger
+    action: disableContextMenu ? MAGIC : undefined,
+    onTouchStart: useTypeScriptHappyCallback((e) => {
+      if (disableContextMenu) {
+        console.error("Context menu is disabled while touching the screen")
+      }
+      if (e.nativeEvent.touches.length !== 1) return
+      const touch = e.nativeEvent.touches[0]
+      if (!touch) return
+      const windowWidth = Dimensions.get("window").width
+      const threshold = windowWidth * 0.97
+      if (touch.pageX > threshold) {
+        // Disable context menu if touch is on the right side of the screen
+        setDisableContextMenu(true)
+        return
+      }
+    }, []),
+    onTouchEnd: useTypeScriptHappyCallback(() => {
+      setDisableContextMenu(false)
+    }, []),
+    asChild: true,
+  } satisfies Parameters<typeof ZeegoContextMenu.Trigger>[0]
+
+  if (!isAndroid) {
+    // On iOS, we don't need to prevent context menu on edge
+    return {}
+  }
+  return contextMenuHandlerProps
 }
 
 export { ContextMenu }


### PR DESCRIPTION
Fix https://github.com/RSSNext/Folo/issues/3776

Introduce functionality to prevent the context menu from appearing when a touch occurs near the edge of the screen on Android devices. This enhancement improves user experience by avoiding accidental context menu triggers.