### PR TITLE
fix: resolve MCP service and context block typings

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/context-bar/blocks/ContextBlock.tsx
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/context-bar/blocks/ContextBlock.tsx
@@ -71,8 +71,8 @@ export const ContextBlock: FC<{ block: AIChatContextBlock }> = memo(({ block }) 
             <div className="flex items-center gap-1.5">
               <div className="relative">
                 <ImageThumbnail
-                  previewUrl={previewUrl || dataUrl}
-                  originalUrl={dataUrl}
+                  previewUrl={previewUrl || dataUrl || ""}
+                  originalUrl={dataUrl || ""}
                   alt={name}
                   filename={name}
                   className={"m-0.5 size-5 rounded-md"}

--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/ai-block-constants.ts
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/ai-block-constants.ts
@@ -123,6 +123,8 @@ export function isImageAttachment(block: AIChatContextBlock): boolean {
  * Gets display content for file attachments based on upload status
  */
 export function getFileDisplayContent(attachment: FileAttachment): string {
-  const statusLabel = FILE_STATUS_LABELS[attachment.uploadStatus]
+  const status = attachment.uploadStatus
+  const statusLabel =
+    status !== undefined ? FILE_STATUS_LABELS[status as keyof typeof FILE_STATUS_LABELS] : undefined
   return statusLabel || attachment.name
 }

--- a/apps/desktop/layer/renderer/src/modules/ai-chat/utils/file-processing.ts
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/utils/file-processing.ts
@@ -202,6 +202,7 @@ export async function uploadFileAttachment(
     onProgressUpdate?.(currentAttachment)
 
     const { dataUrl } = fileAttachment
+    if (!dataUrl) throw new Error("Missing data URL")
     const blob = await fetch(dataUrl).then((r) => r.blob())
 
     // TODO: Replace with real progress tracking when followApi supports it

--- a/apps/desktop/layer/renderer/src/queries/mcp.ts
+++ b/apps/desktop/layer/renderer/src/queries/mcp.ts
@@ -1,5 +1,5 @@
 import type { MCPService } from "@follow/shared/settings/interface"
-import type { UpdateConnectionRequest } from "@follow-app/client-sdk"
+import type { McpConnectionInfo, UpdateConnectionRequest } from "@follow-app/client-sdk"
 
 import { followApi } from "~/lib/api-client"
 
@@ -14,7 +14,11 @@ export const createMCPConnection = async (connectionData: {
 
 export const fetchMCPConnections = async (): Promise<MCPService[]> => {
   const response = await followApi.mcp.getConnections()
-  return response.data
+  return response.data.map(
+    (service: McpConnectionInfo): MCPService => ({
+      ...service,
+    }),
+  )
 }
 
 export const updateMCPConnection = async (


### PR DESCRIPTION
## Summary
- align MCP connection fetching with updated service types
- guard optional file attachment URLs and status checks to satisfy TypeScript

## Testing
- `pnpm test`
- `pnpm --filter @follow/web typecheck`
- `pnpm exec eslint apps/desktop/layer/renderer/src/queries/mcp.ts apps/desktop/layer/renderer/src/modules/ai-chat/components/context-bar/blocks/ContextBlock.tsx apps/desktop/layer/renderer/src/modules/ai-chat/components/message/ai-block-constants.ts apps/desktop/layer/renderer/src/modules/ai-chat/utils/file-processing.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce68dc0883339c3da0244814d6ae