### PR TITLE
chore: set ignorePatchFailures to false

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ overrides:
   "@floating-ui/react-dom": 2.1.4
   "@floating-ui/react": 0.27.14
 
+ignorePatchFailures: false
 patchedDependencies:
   immer@10.1.1: patches/immer@10.1.1.patch
   re-resizable@6.11.2: patches/re-resizable@6.11.2.patch


### PR DESCRIPTION
Ensure that the `ignorePatchFailures` option is set to false in the pnpm workspace configuration to prevent patch failures from being ignored.