### PR TITLE
fix: preserve unchanged fields when editing feed on mobile

### DIFF
--- a/apps/mobile/src/modules/feed/FollowFeed.tsx
+++ b/apps/mobile/src/modules/feed/FollowFeed.tsx
@@ -5,7 +5,7 @@ import { subscriptionSyncService } from "@follow/store/subscription/store"
 import type { SubscriptionForm } from "@follow/store/subscription/types"
 import { formatNumber } from "@follow/utils"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { View } from "react-native"
@@ -82,26 +82,24 @@ function FollowImpl(props: { feedId: string; defaultView?: FeedViewType }) {
   const feed = useFeedById(id)
   const subscription = useSubscriptionByFeedId(feed?.id)
   const isSubscribed = !!subscription
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
-    defaultValues: {
+  const defaultFormValues = useMemo(() => {
+    return {
       category: subscription?.category ?? undefined,
       isPrivate: subscription?.isPrivate ?? undefined,
       hideFromTimeline: subscription?.hideFromTimeline ?? undefined,
       title: subscription?.title ?? undefined,
       view: subscription?.view ?? defaultView,
-    },
+    }
+  }, [subscription, defaultView])
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaultFormValues,
   })
   useEffect(() => {
-    form.reset(
-      {
-        view: subscription?.view ?? defaultView,
-      },
-      {
-        keepDirtyValues: true,
-      },
-    )
-  }, [defaultView, form, subscription?.view])
+    form.reset(defaultFormValues, {
+      keepDirtyValues: true,
+    })
+  }, [defaultFormValues, form])
   const [isLoading, setIsLoading] = useState(false)
   const navigate = useNavigation()
   const canDismiss = useCanDismiss()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes #4483.

On mobile, there is a `useEffect` which resets the form values, and it was removing all properties other than `view`. I've updated it to now include all of the default values when resetting.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
