### PR TITLE
feat: enhance modal layout with improved styling and structure

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -370,30 +370,33 @@ export const ModalInternal = memo(function Modal({
                   defaultSize={resizeDefaultSize}
                   className="flex grow flex-col"
                 >
-                  <div className={"relative flex items-center"}>
-                    <Dialog.Title
-                      className="text-text flex w-0 max-w-full grow items-center gap-2 px-2 py-1 text-base font-medium"
-                      onPointerDownCapture={handleDrag}
-                      onPointerDown={relocateModal}
-                    >
-                      {!!icon && <span className="center flex size-4">{icon}</span>}
-                      <EllipsisHorizontalTextWithTooltip className="truncate">
-                        <span>{title}</span>
-                      </EllipsisHorizontalTextWithTooltip>
-                    </Dialog.Title>
-                    {canClose && (
-                      <Dialog.DialogClose
-                        className="center hover:bg-fill-quaternary text-text-secondary hover:text-text z-[2] -mr-1 rounded-lg p-2"
-                        tabIndex={1}
-                        onClick={close}
+                  <div className={"bg-background relative z-10 flex flex-col"}>
+                    <div className={"flex items-center"}>
+                      <Dialog.Title
+                        className="text-text flex w-0 max-w-full grow items-center gap-2 px-2 py-1 text-base font-medium"
+                        onPointerDownCapture={handleDrag}
+                        onPointerDown={relocateModal}
                       >
-                        <i className="i-mgc-close-cute-re" />
-                      </Dialog.DialogClose>
+                        {!!icon && <span className="center flex size-4">{icon}</span>}
+                        <EllipsisHorizontalTextWithTooltip className="truncate">
+                          <span>{title}</span>
+                        </EllipsisHorizontalTextWithTooltip>
+                      </Dialog.Title>
+                      {canClose && (
+                        <Dialog.DialogClose
+                          className="center hover:bg-fill-quaternary text-text-secondary hover:text-text z-[2] -mr-1 rounded-lg p-2"
+                          tabIndex={1}
+                          onClick={close}
+                        >
+                          <i className="i-mgc-close-cute-re" />
+                        </Dialog.DialogClose>
+                      )}
+                    </div>
+
+                    {(title || icon || canClose) && (
+                      <div className="bg-border mx-1 mt-1 h-px shrink-0" />
                     )}
                   </div>
-                  {(title || icon || canClose) && (
-                    <div className="bg-border mx-1 mt-1 h-px shrink-0" />
-                  )}
 
                   <div
                     className={cn(


### PR DESCRIPTION
<table>
<tr>
 <td>
Before
 <td>
<img width="1368" height="624" alt="CleanShot 2025-09-19 at 11 11 27@2x" src="https://github.com/user-attachments/assets/12f03265-38fc-4c4b-a4f4-a2665c840dad" />
<tr>
 <td>
After
 <td>
<img width="1296" height="326" alt="CleanShot 2025-09-19 at 11 24 12@2x" src="https://github.com/user-attachments/assets/48ab7307-a126-4450-b52e-492dcddd36f4" />


</table>

