### PR TITLE
feat: add video playback control in preview media

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/PreviewMediaContent.tsx
@@ -21,6 +21,7 @@ import { ipcServices } from "~/lib/client"
 import { replaceImgUrlIfNeed } from "~/lib/img-proxy"
 
 import { useCurrentModal } from "../modal/stacked/hooks"
+import type { VideoPlayerRef } from "./VideoPlayer"
 import { VideoPlayer } from "./VideoPlayer"
 
 // Calculate the dynamic scale value and offset
@@ -264,6 +265,7 @@ export const PreviewMediaContent: FC<{
   children?: React.ReactNode
   onZoomChange?: (isZoomed: boolean) => void
 }> = ({ media, initialIndex = 0, children, onZoomChange }) => {
+  const videoRefs = useRef<VideoPlayerRef[]>([])
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, startIndex: initialIndex }, [
     WheelGesturesPlugin(),
   ])
@@ -296,6 +298,18 @@ export const PreviewMediaContent: FC<{
     $container.addEventListener("keydown", handleKeyDown)
     return () => $container.removeEventListener("keydown", handleKeyDown)
   }, [emblaApi, ref])
+
+  // Pause all videos when slide change
+  // And play the current video if it's a video
+  useEffect(() => {
+    videoRefs.current.forEach((video) => {
+      video.controls.pause()
+    })
+    const currentVideo = videoRefs.current[currentSlideIndex]
+    if (currentVideo) {
+      currentVideo.controls.play()
+    }
+  }, [currentSlideIndex])
 
   if (media.length === 0) return null
   if (media.length === 1) {
@@ -342,8 +356,12 @@ export const PreviewMediaContent: FC<{
               <div className="mr-2 flex w-full flex-none items-center justify-center" key={med.url}>
                 {med.type === "video" ? (
                   <VideoPlayer
+                    ref={(el) => {
+                      if (videoRefs.current && el) {
+                        videoRefs.current.push(el)
+                      }
+                    }}
                     src={med.url}
-                    autoPlay
                     muted
                     controls
                     className="size-full object-contain"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

fix: #4504 

The `VideoPlayer` has `autoplay` attribute. So if we open the video in media, all videos will be playing.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
