### PR TITLE
docs(readme): add Flatpak install method via FlatPark

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Feel free to try it using the following methods:
 You can also install using the following methods maintained by our community:
 
 - If you are using Arch Linux, you can install the package [folo-appimage](https://aur.archlinux.org/packages/folo-appimage) that is maintained by [timochan](https://github.com/ttimochan) and [grtsinry43](https://github.com/grtsinry43).
+- If you are using Linux with [Flatpak](https://flatpak.org), you can install [Folo](https://flatpark.org/apps/is.folo.Folo/) from [FlatPark](https://flatpark.org) that is maintained by [Komh](https://github.com/jing2uo).
 - If you are using Nix, you can install the package [follow](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/fo/follow/package.nix) that is maintained by [iosmanthus](https://github.com/iosmanthus).
 - If you are using macOS with [Homebrew](https://brew.sh), you can install the cask [folo](https://formulae.brew.sh/cask/folo) that is maintained by [realSunyz](https://github.com/realSunyz).
 - If you are using Windows with [Scoop](https://scoop.sh), you can install the manifest [folo](https://github.com/cscnk52/cetacea/blob/master/bucket/folo.json) that is maintained by [cscnk52](https://github.com/cscnk52).


### PR DESCRIPTION
  ### Description

  Adds a line to the "community install methods" list in `README.md` for Linux
  users on Flatpak.

  Folo is now listed on [FlatPark](https://flatpark.org/apps/is.folo.Folo/) — the
  Linux AppImage repackaged unmodified as an `extra-data` Flatpak (extracted at
  install time, not rebuilt), with zypak wiring Chromium's sandbox onto the Flatpak
  sandbox so the app keeps its internal sandbox instead of `--no-sandbox`. It gives
  users a menu entry, icon, `folo://` scheme handler and per-app data isolation
  without touching the release artifacts.

  Follow-up to #5078 (same maintainer). Docs-only — one line, mirroring the format
  of the existing Arch / Nix / Homebrew / Scoop entries.

  ### PR Type

  - [ ] Feature
  - [ ] Bugfix
  - [ ] Hotfix
  - [x] Other (please describe): Documentation — README install methods

  ### Screenshots (if UI change)

  n/a

  ### Demo Video (if new feature)

  n/a

  ### Linked Issues

  None. Follows up on #5078.

  ### Additional context

  Nothing in particular to focus on — a single Markdown list item. The linked
  FlatPark listing and package recipe are maintained by me.

  ### Changelog

  - [x] I have updated the changelog/next.md with my changes.
        n/a — README-only, no user-facing app change; nothing to add to
        `changelog/next.md`.
