### PR TITLE
fix(tray): Linux tray icon duplicates and dead menus on minimize-to-tray toggle

### DIFF
--- a/apps/desktop/changelog/next.md
+++ b/apps/desktop/changelog/next.md
@@ -4,8 +4,12 @@
 
 ## Improvements
 
+- On Linux, turning off "Minimize to tray" now offers to restart Folo so the tray icon is actually removed
+
 ## No longer broken
+
+- Fixed the system tray icon piling up on Linux (waybar, KDE Plasma) every time "Minimize to tray" was toggled, leaving dead icons whose menus did nothing
 
 ## Thanks
 
-Special thanks to volunteer contributors @ for their valuable contributions
+Special thanks to volunteer contributor @jing2uo for fixing the Linux system tray icon

--- a/apps/desktop/layer/main/src/ipc/services/app.ts
+++ b/apps/desktop/layer/main/src/ipc/services/app.ts
@@ -129,6 +129,12 @@ export class AppService extends IpcService {
   }
 
   @IpcMethod()
+  relaunch(): void {
+    app.relaunch()
+    app.exit(0)
+  }
+
+  @IpcMethod()
   readClipboard(): string {
     return clipboard.readText()
   }

--- a/apps/desktop/layer/main/src/ipc/services/setting.ts
+++ b/apps/desktop/layer/main/src/ipc/services/setting.ts
@@ -59,8 +59,8 @@ export class SettingService extends IpcService {
   }
 
   @IpcMethod()
-  setMinimizeToTray(minimize: boolean): void {
-    setTrayConfig(minimize)
+  setMinimizeToTray(minimize: boolean): boolean {
+    return setTrayConfig(minimize)
   }
 
   @IpcMethod()

--- a/apps/desktop/layer/main/src/lib/tray.test.ts
+++ b/apps/desktop/layer/main/src/lib/tray.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
     isMacOS: false,
     isMAS: false,
     isWindows: false,
+    isLinux: false,
   }
 
   return {
@@ -113,6 +114,7 @@ describe("tray", () => {
     mocks.env.isMacOS = false
     mocks.env.isMAS = false
     mocks.env.isWindows = false
+    mocks.env.isLinux = false
     mocks.getBadgeCount.mockReturnValue(0)
     mocks.store.get.mockReturnValue(true)
     mocks.trayInstances.length = 0
@@ -127,5 +129,33 @@ describe("tray", () => {
     expect(mocks.trayInstances).toHaveLength(1)
     expect(mocks.trayInstances[0]!.destroy).not.toHaveBeenCalled()
     expect(mocks.trayInstances[0]!.setContextMenu).toHaveBeenCalledTimes(2)
+  })
+
+  it("destroys the native tray when disabled off Linux", async () => {
+    const { registerAppTray, setTrayConfig } = await import("./tray")
+
+    registerAppTray()
+    const needsRestart = setTrayConfig(false)
+
+    expect(mocks.trayInstances[0]!.destroy).toHaveBeenCalledTimes(1)
+    expect(needsRestart).toBe(false)
+  })
+
+  it("keeps the native tray on Linux when disabled and reports a restart is needed", async () => {
+    // Electron's Tray.destroy() can't remove a StatusNotifierItem icon while the
+    // process runs, so recreating it would stack a dead icon. Keep the instance
+    // and let the caller offer a restart instead.
+    mocks.env.isLinux = true
+    const { registerAppTray, setTrayConfig } = await import("./tray")
+
+    registerAppTray()
+    const needsRestart = setTrayConfig(false)
+
+    expect(mocks.trayInstances[0]!.destroy).not.toHaveBeenCalled()
+    expect(needsRestart).toBe(true)
+
+    // Re-enabling reuses the same instance rather than creating a second one.
+    setTrayConfig(true)
+    expect(mocks.trayInstances).toHaveLength(1)
   })
 })

--- a/apps/desktop/layer/main/src/lib/tray.ts
+++ b/apps/desktop/layer/main/src/lib/tray.ts
@@ -1,7 +1,7 @@
 import { name } from "@pkg"
 import { app, Menu, nativeImage, Tray } from "electron"
 
-import { isMacOS, isMAS, isWindows } from "~/env"
+import { isLinux, isMacOS, isMAS, isWindows } from "~/env"
 import { getTrayIconPath } from "~/helper"
 import { logger, revealLogFile } from "~/logger"
 import { WindowManager } from "~/manager/window"
@@ -115,21 +115,48 @@ const showWindow = () => {
 }
 
 const destroyAppTray = () => {
-  if (tray) {
-    tray.destroy()
-    tray = null
-  }
+  if (!tray) return
+
+  // On Linux, `Tray.destroy()` does not remove the icon from StatusNotifierItem
+  // trays (waybar, KDE Plasma, …). Chromium's StatusIconLinuxDbus un-exports its
+  // own D-Bus objects but never tells `org.kde.StatusNotifierWatcher` the item
+  // is gone, and the item is registered by object path on the process-wide
+  // session-bus connection whose name outlives the tray — so the host gets no
+  // `NameOwnerChanged` and keeps a dead icon. Toggling `minimizeToTray` back on
+  // then stacks a *second* icon (Chromium bumps its global StatusNotifierItem
+  // id), with only the newest menu wired to live handlers. The whole pile only
+  // clears when the app fully exits.
+  //
+  // Keep the single Tray instance for the app's lifetime on Linux. The window
+  // close handler reads `getTrayConfig()` on every close, so a tray icon that
+  // outlives a disabled setting is inert; the renderer asks the user to restart
+  // to actually remove it (see `setTrayConfig`'s return value).
+  //
+  // Refs: #3940, #4985, #3207
+  if (isLinux) return
+
+  tray.destroy()
+  tray = null
 }
 
 const DEFAULT_MINIMIZE_TO_TRAY = false
 
 export const getTrayConfig = () => store.get("minimizeToTray") ?? DEFAULT_MINIMIZE_TO_TRAY
 
-export const setTrayConfig = (input: boolean) => {
+/**
+ * @returns `true` when the change could not be applied to the tray icon live and
+ * the app must be restarted for it to take effect (Linux disabling only).
+ */
+export const setTrayConfig = (input: boolean): boolean => {
   store.set("minimizeToTray", input)
   if (input) {
     registerAppTray()
-  } else {
-    destroyAppTray()
+    return false
   }
+
+  // `destroyAppTray()` can't remove the icon on Linux (see above); report that a
+  // restart is needed so the renderer can offer it.
+  const needsRestart = isLinux && tray !== null
+  destroyAppTray()
+  return needsRestart
 }

--- a/apps/desktop/layer/renderer/src/hooks/biz/useTraySetting.ts
+++ b/apps/desktop/layer/renderer/src/hooks/biz/useTraySetting.ts
@@ -1,6 +1,8 @@
 import { IN_ELECTRON } from "@follow/shared/constants"
 import { atom, useAtomValue, useSetAtom } from "jotai"
 import { useCallback } from "react"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import { ipcServices } from "~/lib/client"
 
@@ -19,12 +21,25 @@ export const useMinimizeToTrayValue = () => useAtomValue(minimizeToTrayAtom)
 
 export const useSetMinimizeToTray = () => {
   const setMinimizeToTray = useSetAtom(minimizeToTrayAtom)
+  const { t } = useTranslation("settings")
   return useCallback(
     (value: boolean) => {
       if (!IN_ELECTRON) return
       setMinimizeToTray(value)
-      ipcServices?.setting.setMinimizeToTray(value)
+      void (async () => {
+        // On Linux, disabling the tray can't remove the icon from the running
+        // process (Electron limitation). The main process tells us so; offer a
+        // restart.
+        const needsRestart = await ipcServices?.setting.setMinimizeToTray(value)
+        if (!needsRestart) return
+        toast(t("general.minimize_to_tray.restart_to_remove"), {
+          action: {
+            label: t("general.minimize_to_tray.restart_now"),
+            onClick: () => ipcServices?.app.relaunch(),
+          },
+        })
+      })()
     },
-    [setMinimizeToTray],
+    [setMinimizeToTray, t],
   )
 }

--- a/locales/settings/en.json
+++ b/locales/settings/en.json
@@ -344,6 +344,8 @@
   "general.mark_as_read.title": "Mark as read",
   "general.minimize_to_tray.description": "Minimize to system tray when closing window.",
   "general.minimize_to_tray.label": "Minimize to tray",
+  "general.minimize_to_tray.restart_now": "Restart now",
+  "general.minimize_to_tray.restart_to_remove": "The tray icon will be removed after Folo restarts.",
   "general.network": "Network",
   "general.open_links_in_external_app.label": "Open links in external app",
   "general.privacy": "Privacy",

--- a/locales/settings/zh-CN.json
+++ b/locales/settings/zh-CN.json
@@ -344,6 +344,8 @@
   "general.mark_as_read.title": "标记已读",
   "general.minimize_to_tray.description": "关闭窗口时最小化到系统托盘。",
   "general.minimize_to_tray.label": "最小化到托盘",
+  "general.minimize_to_tray.restart_now": "立即重启",
+  "general.minimize_to_tray.restart_to_remove": "重启 Folo 后托盘图标才会移除。",
   "general.network": "网络",
   "general.open_links_in_external_app.label": "在外部应用内打开链接",
   "general.privacy": "隐私",


### PR DESCRIPTION

  ### Description

  On Linux, toggling **Settings → General → "Minimize to tray"** off and on again
  leaves a dead icon in the system tray every time. After a few toggles the tray
  shows a stack of Folo icons; each opens a context menu but only the newest one's
  menu does anything. The pile only clears when Folo fully quits.

  **Root cause:** `setTrayConfig(false)` calls `tray.destroy()`. On a
  StatusNotifierItem host (waybar, KDE Plasma, …) that does not remove the icon —
  Chromium's `StatusIconLinuxDbus` registers the item by object path on the
  process-wide shared session-bus connection and, on teardown, un-exports its own
  objects but never tells `org.kde.StatusNotifierWatcher` the item is gone. The
  connection name outlives the tray, so the host gets no `NameOwnerChanged` and
  keeps a dead icon. Re-enabling then calls `new Tray()` again and Chromium
  registers a fresh `/org/chromium/StatusNotifierItem/<n+1>`, stacking another.

  **Fix (commit 1):** on Linux, keep the single `Tray` instance for the app's
  lifetime instead of destroying/recreating it on the toggle. `registerAppTray()`
  already guards `new Tray()` behind `if (tray)`, and the window close handler
  reads `getTrayConfig()` on every close, so a tray icon that outlives a disabled
  setting is inert.

  **Follow-up (commit 2):** the icon genuinely can't be removed from a running
  process on Linux (Electron's `Tray` has no hide/visibility API), so
  `setTrayConfig` now returns whether a restart is needed (true only when
  disabling on Linux with a tray present). `settings.setMinimizeToTray` forwards
  that and the renderer shows a toast with a "Restart now" action wired to a new
  `app.relaunch` IPC. Enabling the tray, and all behavior on macOS/Windows, is
  unchanged and takes effect immediately.

  The real fix belongs upstream in Chromium/Electron (`StatusIconLinuxDbus` should
  own a per-item well-known bus name and release it on teardown so hosts get
  `NameOwnerChanged`); this is a workaround until then.

  ### PR Type

  - [x] Bugfix
  - [x] Feature (minor: the "restart to remove the tray icon" prompt)

  ### Screenshots (if UI change)

  <!-- attach: waybar/Plasma tray showing multiple stacked Folo icons BEFORE,
       and a single icon AFTER; plus the "restart to remove the tray icon" toast -->

  ### Demo Video (if new feature)

  ### Linked Issues

  Fixes #3940
  Related: #4985, #3207

  ### Additional context

  Verified on Debian + Hyprland + waybar (Flatpak build, 1.13.0 / Electron 43.1.0).
  D-Bus evidence: `RegisteredStatusNotifierItems` held four
  `:1.XXX/org/chromium/StatusNotifierItem/1..4` entries from a single process;
  `busctl --user tree` showed only `/4` actually exported; `dbus-monitor` showed
  one `RegisterStatusNotifierItem` per toggle and never an unregister; on quit,
  the host dropped all of them at once.

  For review — the trade-off in commit 2: after disabling on Linux the icon
  lingers until the app restarts (the toast's "Restart now" is optional; ignoring
  it just leaves one inert icon, no stacking). Happy to switch to auto-relaunch or
  drop the prompt entirely. The two new i18n strings fall back to `en` in other
  locales.

  ### Changelog

  - [x] I have updated the changelog/next.md with my changes.
        (`apps/desktop/changelog/next.md` — desktop-only change)